### PR TITLE
Fixed logic used to retrieve the currency

### DIFF
--- a/classes/wc-gateway-paypal-express-angelleye.php
+++ b/classes/wc-gateway-paypal-express-angelleye.php
@@ -38,7 +38,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 		$this->gift_receipt_enabled	   = isset($this->settings['gift_receipt_enabled']) ? $this->settings['gift_receipt_enabled'] : '';
 		$this->gift_wrap_name		   = isset($this->settings['gift_wrap_name']) ? $this->settings['gift_wrap_name'] : '';
 		$this->gift_wrap_amount		   = isset($this->settings['gift_wrap_amount']) ? $this->settings['gift_wrap_amount'] : '';
-		
+
         /*
         ' Define the PayPal Redirect URLs.
         ' 	This is the URL that the buyer is first sent to do authorize payment with their paypal account
@@ -239,7 +239,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 'title' => __( 'PayPal Sandbox', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Enable PayPal Sandbox', 'paypal-for-woocommerce' ),
-                'default' => 'yes', 
+                'default' => 'yes',
 				'description' => __( 'The sandbox is PayPal\'s test environment and is only for use with sandbox accounts created within your <a href="http://developer.paypal.com" target="_blank">PayPal developer account</a>.','paypal-for-woocommerce')
             ),
             'debug' => array(
@@ -295,14 +295,14 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 'title' => __( 'Product Page', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Show the Express Checkout button on product detail pages.', 'paypal-for-woocommerce' ),
-                'default' => 'no', 
+                'default' => 'no',
 				'description' => __('Allows customers to checkout using PayPal directly from a product page.','paypal-for-woocommerce')
             ),
             'paypal_account_optional' => array(
                 'title' => __( 'PayPal Account Optional', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Allow customers to checkout without a PayPal account using their credit card.', 'paypal-for-woocommerce' ),
-                'default' => 'no', 
+                'default' => 'no',
 				'description' => __('PayPal Account Optional must be turned on in your PayPal account profile under Website Preferences.','paypal-for-woocommerce')
             ),
 			'landing_page' => array(
@@ -322,7 +322,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                     'detailed' => __( 'Detailed' , 'paypal-for-woocommerce' ),
                     'generic' => __( 'Generic' , 'paypal-for-woocommerce' )
                 ),
-				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details 
+				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details
 									and helps to prevent fraudulant activity on your site.' , 'paypal-for-woocommerce' )
             ),
 			'show_bill_me_later' => array(
@@ -347,21 +347,21 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 'title' => __( 'Gift Wrap', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Enables the gift wrap options for buyers.', 'paypal-for-woocommerce' ),
-                'default' => 'no', 
+                'default' => 'no',
 				'description' => __( 'This will display a gift wrap option to buyers during checkout based on the following Gift Wrap settings.' , 'paypal-for-woocommerce' )
             ),
 			'gift_message_enabled' => array(
                 'title' => __( 'Gift Message', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Enables the gift message widget on PayPal pages.', 'paypal-for-woocommerce' ),
-                'default' => 'no', 
+                'default' => 'no',
 				'description' => __( 'This will allow buyers to enter a message they would like to include with the item as a gift.' , 'paypal-for-woocommerce' )
             ),
 			'gift_receipt_enabled' => array(
                 'title' => __( 'Gift Receipt', 'paypal-for-woocommerce' ),
                 'type' => 'checkbox',
                 'label' => __( 'Enables the gift receipt widget on PayPal pages.', 'paypal-for-woocommerce' ),
-                'default' => 'no', 
+                'default' => 'no',
 				'description' => __( 'This will allow buyers to choose whether or not to include a gift receipt in the order.' , 'paypal-for-woocommerce' )
             ),
 			'gift_wrap_name' => array(
@@ -402,7 +402,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
             )*/
         );
     }
-	
+
     /**
      *  Checkout Message
      */
@@ -454,14 +454,14 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 			/**
 			 * Displays the Bill Me Later checkout button if enabled in EC settings.
 			 */
-			if($this->show_bill_me_later == 'yes') 
+			if($this->show_bill_me_later == 'yes')
 			{
 				// Bill Me Later button
 				$bml_button_markup = '<div id="paypal_ec_bml_button">';
 				$bml_button_markup .= '<a class="paypal_checkout_button" href="' . add_query_arg( 'use_bml', 'true', add_query_arg( 'pp_action', 'expresscheckout', add_query_arg( 'wc-api', 'WC_Gateway_PayPal_Express_AngellEYE', home_url( '/' ) ) ) ) . '" >';
 				$bml_button_markup .= "<img src='https://www.paypalobjects.com/webstatic/en_US/btn/btn_bml_SM.png' width='150' alt='Check out with PayPal Bill Me Later'/>";
 				$bml_button_markup .= '</a>';
-	
+
 				// Marketing Message
 				$bml_button_markup .= '<a target="_blank" href="https://www.securecheckout.billmelater.com/paycapture-content/fetch?hash=AU826TU8&content=/bmlweb/ppwpsiw.html" >';
 				$bml_button_markup .= "<img src='https://www.paypalobjects.com/webstatic/en_US/btn/btn_bml_text.png' width='150' />";
@@ -473,7 +473,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 			echo '<div class="clear"></div></div>';
 			echo '</div>';
 			echo '<div style="clear:both; margin-bottom:10px;"></div>';
-			
+
 			//echo apply_filters( 'woocommerce_ppe_checkout_message', __( 'Have a PayPal account?', 'paypal-for-woocommerce' ) ) . '</p>';
 		}
     }
@@ -493,7 +493,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) )
                     define( 'WOOCOMMERCE_CHECKOUT', true );
                 $this->add_log( 'Start Express Checkout' );
-				
+
 				/**
 				 * Check if the EC button used was the BML button.
 				 * This $useBML flag will be used to adjust the SEC request accordingly.
@@ -506,7 +506,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				{
 					$useBML = false;
 				}
-				
+
                 WC()->cart->calculate_totals();
                 //$paymentAmount    = WC()->cart->get_total();
 				$paymentAmount	  = number_format(WC()->cart->total,2,'.','');
@@ -514,7 +514,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 $cancelURL        = urlencode( WC()->cart->get_cart_url() );
                 $resArray         = $this->CallSetExpressCheckout( $paymentAmount, $returnURL, $cancelURL, $useBML );
                 $ack              = strtoupper( $resArray["ACK"] );
-                
+
 				if($ack == "SUCCESS" || $ack == "SUCCESSWITHWARNING")
 				{
                     $this->add_log( 'Redirecting to PayPal' );
@@ -543,25 +543,25 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                     $message .= __( 'Detailed Error Message: ' , 'paypal-for-woocommerce') . $ErrorLongMsg ."\n";
 
                     wp_mail($admin_email, "PayPal Express Checkout Error Notification",$message);
-					
+
 					// Generate error message based on Error Display Type setting
 					if($this->error_display_type == 'detailed')
 					{
 						$sec_error_notice = $ErrorCode.' - '.$ErrorLongMsg;
-						wc_add_notice(  sprintf( __($sec_error_notice, 'paypal-for-woocommerce' ) ), 'error' );						
+						wc_add_notice(  sprintf( __($sec_error_notice, 'paypal-for-woocommerce' ) ), 'error' );
 					}
 					else
 					{
-						wc_add_notice(  sprintf( __('There was a problem paying with PayPal.  Please try another method.', 'paypal-for-woocommerce' ) ), 'error' );	
+						wc_add_notice(  sprintf( __('There was a problem paying with PayPal.  Please try another method.', 'paypal-for-woocommerce' ) ), 'error' );
 					}
-					
+
                     wp_redirect( get_permalink( wc_get_page_id( 'cart' ) ) );
                     exit;
                 }
             }
         }
 		elseif ( isset( $_GET['pp_action'] ) && $_GET['pp_action'] == 'revieworder' )
-		{	
+		{
             wc_clear_notices();
             // The customer has logged into PayPal and approved order.
             // Retrieve the shipping details and present the order for completion.
@@ -577,9 +577,9 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
             }
             $this->add_log( "...Token:" . $this->get_session( 'TOKEN' ) );
             $this->add_log( "...PayerID: " . $this->get_session( 'PayerID' ) );
-            
+
 			$result = $this->CallGetShippingDetails($this->get_session('TOKEN'));
-			
+
             if(!empty($result))
 			{
                 $this->set_session('RESULT',serialize($result));
@@ -611,7 +611,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				$this->set_session('customer_notes',isset($result['PAYMENTREQUEST_0_NOTETEXT']) ? $result['PAYMENTREQUEST_0_NOTETEXT'] : '');
                 WC()->cart->calculate_totals();
 
-            } 
+            }
 			else
 			{
                 $this->add_log( "...ERROR: GetShippingDetails returned empty result" );
@@ -663,7 +663,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         }
 		elseif ( isset( $_GET['pp_action'] ) && $_GET['pp_action'] == 'payaction' )
 		{
-            if ( isset( $_POST ) ) 
+            if ( isset( $_POST ) )
 			{
                 // Update customer shipping and payment method to posted method
                 $chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
@@ -686,7 +686,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                     define( 'WOOCOMMERCE_CHECKOUT', true );
                 WC()->cart->calculate_totals();
                     $order_id = WC()->checkout()->create_order();
-				
+
 				/**
 				 * Update meta data with session data
 				 */
@@ -703,7 +703,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				update_post_meta( $order_id, '_shipping_country',   $this->get_session('shiptocountrycode'));
 				update_post_meta( $order_id, '_shipping_state',   $this->get_state_code( $this->get_session('shiptocountrycode'), $this->get_session('shiptostate')));
                 update_post_meta( $order_id, '_customer_user', 	get_current_user_id() );
-               
+
                 $this->add_log( '...Order ID: ' . $order_id );
                 $order = new WC_Order( $order_id );
                 do_action( 'woocommerce_ppe_do_payaction', $order );
@@ -711,7 +711,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                 $this->add_log( '...Cart Total: '.WC()->cart->get_total() );
                 $this->add_log( "...Token:" . $this->get_session( 'TOKEN' ) );
                 $result = $this->ConfirmPayment( $order->order_total );
-				
+
 				/**
 				 * Customer Notes
 				 */
@@ -719,16 +719,16 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				{
 					$order->add_order_note(__( 'Customer Notes: ' , 'paypal-for-woocommerce' ).$this->get_session('customer_notes'));
 				}
-				
+
 				if($result['ACK'] == 'Success' || $result['ACK'] == 'SuccessWithWarning')
 				{
                     $this->add_log( 'Payment confirmed with PayPal successfully' );
                     $result = apply_filters( 'woocommerce_payment_successful_result', $result );
-                    
+
 					/**
 					 * Gift Wrap Notes
 					 */
-					if ($this->get_session('giftwrapamount')!='') 
+					if ($this->get_session('giftwrapamount')!='')
 					{
 						$giftwrap_note = __( 'Gift Wrap Added' , 'paypal-for-woocommerce');
 						$giftwrap_note .= $this->get_session('giftwrapname') != '' ? ' - ' . $this->get_session('giftwrapname') : '';
@@ -738,7 +738,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 						//$giftwrap_note .= '<br />Fee: ' . woocommerce_price(number_format($this->get_session('giftwrapamount'),2));
                         $order->add_order_note($giftwrap_note);
                     }
-					
+
                     $order->add_order_note( __( 'PayPal Express payment completed', 'paypal-for-woocommerce' ) .
                         ' ( Response Code: ' . $result['ACK'] . ", " .
                         ' TransactionID: '.$result['PAYMENTINFO_0_TRANSACTIONID'] . ' )' );
@@ -759,7 +759,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				{
                     $this->add_log( '...Error confirming order '.$order_id.' with PayPal' );
                     $this->add_log( '...response:'.print_r( $result, true ) );
-					
+
 					// Display a user friendly Error on the page and log details
                     $ErrorCode         = urldecode( $result["L_ERRORCODE0"] );
                     $ErrorShortMsg     = urldecode( $result["L_SHORTMESSAGE0"] );
@@ -781,21 +781,21 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                     $message.='Detailed Error Message: ' . $ErrorLongMsg ."\n";
 
                     wp_mail($admin_email, "PayPal Express Checkout Error Notification",$message);
-					
+
 					// Generate error message based on Error Display Type setting
 					if($this->error_display_type == 'detailed')
 					{
 						$sec_error_notice = $ErrorCode.' - '.$ErrorLongMsg;
-						wc_add_notice(  sprintf( __($sec_error_notice, 'paypal-for-woocommerce' ) ), 'error' );						
+						wc_add_notice(  sprintf( __($sec_error_notice, 'paypal-for-woocommerce' ) ), 'error' );
 					}
 					else
 					{
-						wc_add_notice(  sprintf( __('There was a problem paying with PayPal.  Please try another method.', 'paypal-for-woocommerce' ) ), 'error' );	
+						wc_add_notice(  sprintf( __('There was a problem paying with PayPal.  Please try another method.', 'paypal-for-woocommerce' ) ), 'error' );
 					}
-					
+
 					wp_redirect(get_permalink(wc_get_page_id('cart')));
 					exit();
-                }				
+                }
             }
         }
     }
@@ -921,7 +921,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         update_post_meta( $order_id, '_customer_user',    ( int ) get_current_user_id() );
         update_post_meta( $order_id, '_order_items',    $order_items );
         update_post_meta( $order_id, '_order_taxes',    $order_taxes );
-        update_post_meta( $order_id, '_order_currency',   get_option( 'woocommerce_currency' ) );
+        update_post_meta( $order_id, '_order_currency',   get_woocommerce_currency() );
         update_post_meta( $order_id, '_prices_include_tax',  get_option( 'woocommerce_prices_include_tax' ) );
         // Order status
         wp_set_object_terms( $order_id, 'pending', 'shop_order_status' );
@@ -1010,7 +1010,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
             'taxidtype' => '', 							// The buyer's tax ID type.  This field is required for Brazil and used for Brazil only.  Values:  BR_CPF for individuals and BR_CNPJ for businesses.
             'taxid' => ''								// The buyer's tax ID.  This field is required for Brazil and used for Brazil only.  The tax ID is 11 single-byte characters for individutals and 14 single-byte characters for businesses.
         );
-		
+
 		/**
 		 * If Gift Wrap options are enabled, add them to SEC
 		 */
@@ -1022,7 +1022,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
             $SECFields['giftwrapname'] = $this->gift_wrap_name; 						// Label for the gift wrap option such as "Box with ribbon".  25 char max.
             $SECFields['giftwrapamount'] = $this->gift_wrap_amount;			// Amount charged for gift-wrap service.
 		}
-		
+
 		/**
 		 * If BML is being used, override the necessary parameters
 		 */
@@ -1030,7 +1030,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 		{
 			$SECFields['solutiontype'] = 'Sole';
 			$SECFields['landingpage'] = 'Billing';
-			$SECFields['userselectedfundingsource'] = 'BML';	
+			$SECFields['userselectedfundingsource'] = 'BML';
 		}
 		elseif(strtolower($this->paypal_account_optional) == 'yes' && strtolower($this->landing_page) == 'billing')
 		{
@@ -1064,7 +1064,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         $Payments = array();
         $Payment = array(
             'amt' => number_format(WC()->cart->total,2,'.',''), 							// Required.  The total cost of the transaction to the customer.  If shipping cost and tax charges are known, include them in this value.  If not, this value should be the current sub-total of the order.
-            'currencycode' => get_option('woocommerce_currency'), 					// A three-character currency code.  Default is USD.
+            'currencycode' => get_woocommerce_currency(), 					// A three-character currency code.  Default is USD.
             'shippingamt' => number_format($shipping,2,'.',''), 					// Total shipping costs for this order.  If you specify SHIPPINGAMT you mut also specify a value for ITEMAMT.
             'shippingdiscamt' => '', 				// Shipping discount for this order, specified as a negative number.
             'insuranceamt' => '', 					// Total shipping insurance costs for this order.
@@ -1157,7 +1157,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
             $total_items += $product_price*$values['quantity'];
             $ctr++;
         }
-		
+
 		/**
 		 * Add custom Woo cart fees as line items
 		 */
@@ -1442,7 +1442,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         $Payments = array();
         $Payment = array(
             'amt' => number_format($FinalPaymentAmt,2,'.',''), 							// Required.  The total cost of the transaction to the customer.  If shipping cost and tax charges are known, include them in this value.  If not, this value should be the current sub-total of the order.
-            'currencycode' => get_option('woocommerce_currency'), 					// A three-character currency code.  Default is USD.
+            'currencycode' => get_woocommerce_currency(), 					// A three-character currency code.  Default is USD.
             'shippingdiscamt' => '', 				// Total shipping discount for this order, specified as a negative number.
             'insuranceoptionoffered' => '', 		// If true, the insurance drop-down on the PayPal review page displays the string 'Yes' and the insurance amount.  If true, the total shipping insurance for this order must be a positive number.
             'handlingamt' => '', 					// Total handling costs for this order.  If you specify HANDLINGAMT you mut also specify a value for ITEMAMT.
@@ -1533,7 +1533,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 
                 $ITEMAMT += $product_price * $values['qty'];
             }
-			
+
 			/**
 			 * Add custom Woo cart fees as line items
 			 */
@@ -1560,20 +1560,20 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 					'ebayitemorderid' => '', // Auction order ID number.
 					'ebayitemcartid' => '' // The unique identifier provided by eBay for this order from the buyer. These parameters must be ordered sequentially beginning with 0 (for example L_EBAYITEMCARTID0, L_EBAYITEMCARTID1). Character length: 255 single-byte characters
 				);
-				
+
 				/**
-				 * The gift wrap amount actually has its own parameter in 
+				 * The gift wrap amount actually has its own parameter in
 				 * DECP, so we don't want to include it as one of the line
 				 * items.
 				 */
 				if($Item['number'] != 'gift-wrap')
-				{	
+				{
 					array_push($PaymentOrderItems, $Item);
 					$ITEMAMT += $fee->amount*$Item['qty'];
 				}
-				
+
 				$ctr++;
-	
+
 			}
 
             /*
@@ -1788,7 +1788,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 
         }
     }
-	
+
     /**
      *  Checkout Button
      *
@@ -1798,11 +1798,11 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
     static function woocommerce_paypal_express_checkout_button_angelleye()
 	{
         global $pp_settings, $pp_pro, $pp_payflow;
-		
+
 		/*echo '<pre />';
 		print_r($pp_settings);
 		exit();*/
-		
+
         if (@$pp_settings['enabled']=='yes' && 0 < WC()->cart->total )
 		{
             $payment_gateways = WC()->payment_gateways->get_available_payment_gateways();

--- a/classes/wc-gateway-paypal-pro-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-angelleye.php
@@ -136,7 +136,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
             'sandbox_api_username' => array(
                 'title' => __( 'Sandbox API Username', 'paypal-for-woocommerce' ),
                 'type' => 'text',
-                'description' => __( 'Create sandbox accounts and obtain API credentials from within your 
+                'description' => __( 'Create sandbox accounts and obtain API credentials from within your
 									<a href="http://developer.paypal.com">PayPal developer account</a>.', 'paypal-for-woocommerce' ),
                 'default' => ''
             ),
@@ -153,7 +153,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
             'api_username' => array(
                 'title' => __( 'Live API Username', 'paypal-for-woocommerce' ),
                 'type' => 'text',
-                'description' => __( 'Get your live account API credentials from your PayPal account profile under the API Access section <br />or by using 
+                'description' => __( 'Get your live account API credentials from your PayPal account profile under the API Access section <br />or by using
 									<a target="_blank" href="https://www.paypal.com/us/cgi-bin/webscr?cmd=_login-api-run">this tool</a>.', 'paypal-for-woocommerce' ),
                 'default' => ''
             ),
@@ -208,7 +208,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
                     'detailed' => __( 'Detailed' , 'paypal-for-woocommerce' ),
                     'generic' => __( 'Generic' , 'paypal-for-woocommerce' )
                 ),
-				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details 
+				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details
 									and helps to prevent fraudulant activity on your site.' , 'paypal-for-woocommerce')
             ),
             /*'send_items' => array(
@@ -237,7 +237,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
         if ($this->enabled=="yes") :
             if ( $this->testmode == "no" && get_option('woocommerce_force_ssl_checkout')=='no' && !class_exists( 'WordPressHTTPS' ) ) return false;
             // Currency check
-            if ( ! in_array( get_option( 'woocommerce_currency' ), apply_filters( 'woocommerce_paypal_pro_allowed_currencies', array( 'AUD', 'CAD', 'CZK', 'DKK', 'EUR', 'HUF', 'JPY', 'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD' ) ) ) ) return false;
+            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_paypal_pro_allowed_currencies', array( 'AUD', 'CAD', 'CZK', 'DKK', 'EUR', 'HUF', 'JPY', 'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD' ) ) ) ) return false;
             // Required fields check
             if (!$this->api_username || !$this->api_password || !$this->api_signature) return false;
             return isset($this->avaiable_card_types[WC()->countries->get_base_country()]);
@@ -395,7 +395,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
             // Standard cmpi_lookup fields
             $centinelClient->add('OrderNumber', $order_id);
             $centinelClient->add('Amount', $order->order_total * 100 );
-            $centinelClient->add('CurrencyCode', $this->iso4217[get_option('woocommerce_currency')]);
+            $centinelClient->add('CurrencyCode', $this->iso4217[get_woocommerce_currency()]);
             $centinelClient->add('TransactionMode', 'S');
             // Items
             $item_loop = 0;
@@ -577,33 +577,33 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 		{
             wc_add_notice(sprintf(__( 'Sorry, your session has expired. <a href=%s>Return to homepage &rarr;</a>', 'paypal-for-woocommerce' ), '"'.home_url().'"'),"error");
 		}
-		
+
 		/*
 		 * Check if the PayPal class has already been established.
 		 */
-		if(!class_exists('PayPal' )) 
+		if(!class_exists('PayPal' ))
 		{
-			require_once( 'lib/angelleye/paypal-php-library/includes/paypal.class.php' );	
+			require_once( 'lib/angelleye/paypal-php-library/includes/paypal.class.php' );
 		}
-		
+
 		/*
 		 * Create PayPal object.
 		 */
 		$PayPalConfig = array(
-			'Sandbox' => $this->testmode == 'yes' ? TRUE : FALSE, 
+			'Sandbox' => $this->testmode == 'yes' ? TRUE : FALSE,
 			'APIUsername' => $this->api_username,
-			'APIPassword' => $this->api_password, 
+			'APIPassword' => $this->api_password,
 			'APISignature' => $this->api_signature
 		);
 		$PayPal = new PayPal($PayPalConfig);
-		
+
 		if(empty($GLOBALS['wp_rewrite']))
 		{
-            $GLOBALS['wp_rewrite'] = new WP_Rewrite();	
+            $GLOBALS['wp_rewrite'] = new WP_Rewrite();
 		}
-		
+
 		$card_exp = $card_exp_month . $card_exp_year;
-		
+
 		/**
 		 * Generate PayPal request
 		 */
@@ -612,22 +612,22 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 							'ipaddress' => $this->get_user_ip(), 							// Required.  IP address of the payer's browser.
 							'returnfmfdetails' => '' 					// Flag to determine whether you want the results returned by FMF.  1 or 0.  Default is 0.
 						);
-						
+
 		$CCDetails = array(
 							'creditcardtype' => $card_type, 					// Required. Type of credit card.  Visa, MasterCard, Discover, Amex, Maestro, Solo.  If Maestro or Solo, the currency code must be GBP.  In addition, either start date or issue number must be specified.
-							'acct' => $card_number, 								// Required.  Credit card number.  No spaces or punctuation.  
+							'acct' => $card_number, 								// Required.  Credit card number.  No spaces or punctuation.
 							'expdate' => $card_exp, 							// Required.  Credit card expiration date.  Format is MMYYYY
 							'cvv2' => $card_csc, 								// Requirements determined by your PayPal account settings.  Security digits for credit card.
 							'startdate' => '', 							// Month and year that Maestro or Solo card was issued.  MMYYYY
 							'issuenumber' => ''							// Issue number of Maestro or Solo card.  Two numeric digits max.
 						);
-						
+
 		$PayerInfo = array(
 							'email' => $order->billing_email, 								// Email address of payer.
 							'firstname' => $order->billing_first_name, 							// Required.  Payer's first name.
 							'lastname' => $order->billing_last_name 							// Required.  Payer's last name.
 						);
-						
+
 		$BillingAddress = array(
 								'street' => $order->billing_address_1, 						// Required.  First street address.
 								'street2' => $order->billing_address_2, 						// Second street address.
@@ -637,7 +637,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 								'zip' => $order->billing_postcode, 							// Required.  Postal code of payer.
 								'phonenum' => $order->billing_phone 						// Phone Number of payer.  20 char max.
 							);
-							
+
 		$ShippingAddress = array(
 								'shiptoname' => $order->shipping_first_name.' '.$order->shipping_last_name, 					// Required if shipping is included.  Person's name associated with this address.  32 char max.
 								'shiptostreet' => $order->shipping_address_1, 					// Required if shipping is included.  First street address.  100 char max.
@@ -648,11 +648,11 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 								'shiptocountry' => $order->shipping_country, 					// Required if shipping is included.  Country code of shipping address.  2 char max.
 								'shiptophonenum' => $order->shipping_phone					// Phone number for shipping address.  20 char max.
 								);
-							
+
 		$PaymentDetails = array(
-								'amt' => $order->get_total(), 							// Required.  Total amount of order, including shipping, handling, and tax.  
-								'currencycode' => get_option('woocommerce_currency'), 					// Required.  Three-letter currency code.  Default is USD.
-								'insuranceamt' => '', 					// Total shipping insurance costs for this order.  
+								'amt' => $order->get_total(), 							// Required.  Total amount of order, including shipping, handling, and tax.
+								'currencycode' => get_woocommerce_currency(), 					// Required.  Three-letter currency code.  Default is USD.
+								'insuranceamt' => '', 					// Total shipping insurance costs for this order.
 								'shipdiscamt' => '', 					// Shipping discount for the order, specified as a negative number.
 								'handlingamt' => '', 					// Total handling costs for the order.  If you specify handlingamt, you must also specify itemamt.
 								'desc' => '', 							// Description of the order the customer is purchasing.  127 char max.
@@ -661,9 +661,9 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 								'notifyurl' => '', 						// URL for receiving Instant Payment Notifications.  This overrides what your profile is set to use.
 								'recurring' => ''						// Flag to indicate a recurring transaction.  Value should be Y for recurring, or anything other than Y if it's not recurring.  To pass Y here, you must have an established billing agreement with the buyer.
 							);
-		
-				
-		$OrderItems = array();		
+
+
+		$OrderItems = array();
 		$item_loop = 0;
         if ( sizeof( $order->get_items() ) > 0 ) {
             $ITEMAMT = $TAXAMT = 0;
@@ -686,7 +686,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
                             $item['name'] .= " - ".str_replace(", \n", " - ",$meta);
                         }
                     }
-					
+
 					/**
 					 * Get price based on text setting.
 					 */
@@ -698,13 +698,13 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 					{
                         $product_price = $order->get_item_subtotal($item,false,true);
                     }
-					
+
 					$Item	 = array(
 									'l_name' => $item['name'], 						// Item Name.  127 char max.
 									'l_desc' => '', 						// Item description.  127 char max.
 									'l_amt' => number_format($product_price,2,'.',''), 							// Cost of individual item.
 									'l_number' => $sku, 						// Item Number.  127 char max.
-									'l_qty' => $item['qty'], 							// Item quantity.  Must be any positive integer.  
+									'l_qty' => $item['qty'], 							// Item quantity.  Must be any positive integer.
 									'l_taxamt' => '', 						// Item's sales tax amount.
 									'l_ebayitemnumber' => '', 				// eBay auction number of item.
 									'l_ebayitemauctiontxnid' => '', 		// eBay transaction ID of purchased item.
@@ -727,7 +727,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 									'l_desc' => '', 						// Item description.  127 char max.
 									'l_amt' => '-'.WC()->cart->coupon_discount_amounts[$code], 							// Cost of individual item.
 									'l_number' => $code, 						// Item Number.  127 char max.
-									'l_qty' => '1', 							// Item quantity.  Must be any positive integer.  
+									'l_qty' => '1', 							// Item quantity.  Must be any positive integer.
 									'l_taxamt' => '', 						// Item's sales tax amount.
 									'l_ebayitemnumber' => '', 				// eBay auction number of item.
 									'l_ebayitemauctiontxnid' => '', 		// eBay transaction ID of purchased item.
@@ -735,7 +735,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 									);
 					array_push($OrderItems, $Item);
                 }
-				
+
                 $ITEMAMT = $ITEMAMT - $order->get_cart_discount();
             }
 
@@ -749,7 +749,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 									'l_desc' => '', 						// Item description.  127 char max.
 									'l_amt' => '-'.WC()->cart->coupon_discount_amounts[$code], 							// Cost of individual item.
 									'l_number' => $code, 						// Item Number.  127 char max.
-									'l_qty' => '1', 							// Item quantity.  Must be any positive integer.  
+									'l_qty' => '1', 							// Item quantity.  Must be any positive integer.
 									'l_taxamt' => '', 						// Item's sales tax amount.
 									'l_ebayitemnumber' => '', 				// eBay auction number of item.
 									'l_ebayitemauctiontxnid' => '', 		// eBay transaction ID of purchased item.
@@ -757,10 +757,10 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 									);
 					array_push($OrderItems, $Item);
                 }
-				
+
                 $ITEMAMT = $ITEMAMT - $order->get_order_discount();
             }
-			
+
 			/**
 			 * Get shipping and tax.
 			 */
@@ -777,7 +777,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 
             if ($tax>0)
 			{
-				$PaymentDetails['taxamt'] = $tax; 						// Required if you specify itemized cart tax details. Sum of tax for all items on the order.  Total sales tax. 
+				$PaymentDetails['taxamt'] = $tax; 						// Required if you specify itemized cart tax details. Sum of tax for all items on the order.  Total sales tax.
             }
 
             if($shipping > 0)
@@ -785,7 +785,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 				$PaymentDetails['shippingamt'] = $shipping;					// Total shipping costs for the order.  If you specify shippingamt, you must also specify itemamt.
             }
         }
-		
+
 		/**
 		 * Add custom Woo cart fees as line items
 		 */
@@ -814,42 +814,42 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 				'ebayitemorderid' => '', // Auction order ID number.
 				'ebayitemcartid' => '' // The unique identifier provided by eBay for this order from the buyer. These parameters must be ordered sequentially beginning with 0 (for example L_EBAYITEMCARTID0, L_EBAYITEMCARTID1). Character length: 255 single-byte characters
 			);
-			
-				
+
+
 			array_push($OrderItems, $Item);
-			
+
 			$ITEMAMT += $fee->amount*$Item['qty'];
 			$item_loop++;
 		}
-		
+
 		$PaymentDetails['itemamt'] = number_format($ITEMAMT,2,'.',''); 						// Required if you include itemized cart details. (L_AMTn, etc.)  Subtotal of items not including S&H, or tax.
-		
+
 		/**
 		 * 3D Secure Params
 		 */
         if($this->enable_3dsecure)
 		{
 			$Secure3D = array(
-						  'authstatus3d' => $centinelPAResStatus, 
-						  'mpivendor3ds' => $centinelEnrolled, 
-						  'cavv' => $centinelCavv, 
-						  'eci3ds' => $centinelEciFlag, 
+						  'authstatus3d' => $centinelPAResStatus,
+						  'mpivendor3ds' => $centinelEnrolled,
+						  'cavv' => $centinelCavv,
+						  'eci3ds' => $centinelEciFlag,
 						  'xid' => $centinelXid
 						  );
         }
 		else
 		{
 			$Secure3D = array();
-		}	
-						  
+		}
+
 		$PayPalRequestData = array(
-								   'DPFields' => $DPFields, 
-								   'CCDetails' => $CCDetails, 
-								   'PayerInfo' => $PayerInfo, 
-								   'BillingAddress' => $BillingAddress, 
-								   'ShippingAddress' => $ShippingAddress, 
-								   'PaymentDetails' => $PaymentDetails, 
-								   'OrderItems' => $OrderItems, 
+								   'DPFields' => $DPFields,
+								   'CCDetails' => $CCDetails,
+								   'PayerInfo' => $PayerInfo,
+								   'BillingAddress' => $BillingAddress,
+								   'ShippingAddress' => $ShippingAddress,
+								   'PaymentDetails' => $PaymentDetails,
+								   'OrderItems' => $OrderItems,
 								   'Secure3D' => $Secure3D
 								   );
 
@@ -860,20 +860,20 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
             $log['CCDetails']['cvv2'] = '****';
             $this->log->add('paypal-pro','Do payment request '.print_r($log,true));
         }
-		
+
 		// Pass data into class for processing with PayPal and load the response array into $PayPalResult
 		$PayPalResult = $PayPal->DoDirectPayment($PayPalRequestData);
-		
+
 		if($this->debug)
 		{
             $this->log->add('paypal-pro','Result ' .print_r($PayPalResult, true ) );
 		}
-		
+
 		if(empty($PayPalResult))
 		{
             throw new Exception(__('Empty PayPal response.', 'paypal-for-woocommerce'));
 		}
-		
+
 		if($PayPal->APICallSuccessful($PayPalResult['ACK']))
 		{
 			// Add order note
@@ -882,10 +882,10 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 
 			// Payment complete
 			$order->payment_complete();
-			
+
 			// Remove cart
 			WC()->cart->empty_cart();
-			
+
 			// Return thank you page redirect
 			return array(
 				'result' 	=> 'success',
@@ -898,31 +898,31 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 			$error_code = isset($PayPalResult['ERRORS'][0]['L_ERRORCODE']) ? $PayPalResult['ERRORS'][0]['L_ERRORCODE'] : '';
 			$long_message = isset($PayPalResult['ERRORS'][0]['L_LONGMESSAGE']) ? $PayPalResult['ERRORS'][0]['L_LONGMESSAGE'] : '';
 			$error_message = $error_code.'-'.$long_message;
-			
+
 			if($this->debug)
 			{
                 $this->log->add('paypal-pro','Error '.print_r($PayPalResult['ERRORS'],true));
 			}
-			
-			$order->update_status( 'failed', sprintf(__('PayPal Pro payment failed (Correlation ID: %s). Payment was rejected due to an error: %s', 
+
+			$order->update_status( 'failed', sprintf(__('PayPal Pro payment failed (Correlation ID: %s). Payment was rejected due to an error: %s',
 						'paypal-for-woocommerce'), $PayPalResult['CORRELATIONID'], '(' . $PayPalResult['L_ERRORCODE0'] . ') ' . '"' . $error_message . '"' ) );
-			
+
 			// Generate error message based on Error Display Type setting
 			if($this->error_display_type == 'detailed')
 			{
 				throw new Exception( __( $error_message, 'paypal-for-woocommerce'));
-				wc_add_notice(__('Payment error:', 'paypal-for-woocommerce') . ' ' . $error_message, "error" );		
+				wc_add_notice(__('Payment error:', 'paypal-for-woocommerce') . ' ' . $error_message, "error" );
 			}
 			else
 			{
 				throw new Exception( __( 'There was a problem connecting to the payment gateway.', 'paypal-for-woocommerce'));
-				wc_add_notice(__('Payment error:', 'paypal-for-woocommerce') . ' ' . $error_message, "error" );		
+				wc_add_notice(__('Payment error:', 'paypal-for-woocommerce') . ' ' . $error_message, "error" );
 			}
-			
+
 			return;
 		}
 	}
-	
+
     /**
      * Get user's IP address
      */

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -23,7 +23,7 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway {
 		$this->liveurl				= 'https://payflowpro.paypal.com';
 		$this->testurl				= 'https://pilot-payflowpro.paypal.com';
 		$this->allowed_currencies   = apply_filters( 'woocommerce_paypal_pro_allowed_currencies', array( 'USD', 'EUR', 'GBP', 'CAD', 'JPY', 'AUD' ) );
-		
+
 		// Load the form fields
 		$this->init_form_fields();
 
@@ -127,7 +127,7 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway {
                     'detailed' => 'Detailed',
                     'generic' => 'Generic'
                 ),
-				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details 
+				'description' => __( 'Detailed displays actual errors returned from PayPal.  Generic displays general errors that do not reveal details
 									and helps to prevent fraudulant activity on your site.' , 'paypal-for-woocommerce' )
             ),
             'sandbox_paypal_vendor'   => array(
@@ -198,7 +198,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 				return false;
 
 			// Currency check
-			if ( ! in_array( get_option('woocommerce_currency'), $this->allowed_currencies ) )
+			if ( ! in_array( get_woocommerce_currency(), $this->allowed_currencies ) )
 				return false;
 
 			// Required fields check
@@ -255,28 +255,28 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 		{
             wc_add_notice(sprintf(__( 'Sorry, your session has expired. <a href=%s>Return to homepage &rarr;</a>', 'paypal-for-woocommerce' ), '"'.home_url().'"'),"error");
 		}
-		
+
 		/*
 		 * Check if the PayPal_PayFlow class has already been established.
 		 */
-		if(!class_exists('PayPal_PayFlow' )) 
+		if(!class_exists('PayPal_PayFlow' ))
 		{
 			require_once('lib/angelleye/paypal-php-library/includes/paypal.class.php');
-			require_once('lib/angelleye/paypal-php-library/includes/paypal.payflow.class.php');	
+			require_once('lib/angelleye/paypal-php-library/includes/paypal.payflow.class.php');
 		}
-		
+
 		/**
 		 * Create PayPal_PayFlow object.
 		 */
 		$PayPalConfig = array(
-						'Sandbox' => ($this->testmode=='yes')? true:false, 
-						'APIUsername' => $this->paypal_user, 
-						'APIPassword' => trim($this->paypal_password), 
-						'APIVendor' => $this->paypal_vendor, 
+						'Sandbox' => ($this->testmode=='yes')? true:false,
+						'APIUsername' => $this->paypal_user,
+						'APIPassword' => trim($this->paypal_password),
+						'APIVendor' => $this->paypal_vendor,
 						'APIPartner' => $this->paypal_partner
 					  );
 		$PayPal = new PayPal_PayFlow($PayPalConfig);
-		
+
 		/**
 		 * Pulled from original Woo extension.
 		 */
@@ -284,19 +284,19 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 		{
         	$GLOBALS['wp_rewrite'] = new WP_Rewrite();
 		}
-		
+
 		if($this->debug)
 		{
 			$this->add_log($order->get_checkout_order_received_url());
 		}
-		
+
 		try
 		{
 			/**
 			 * Parameter set by original Woo.  I can probably ditch this, but leaving it for now.
 			 */
 			$url = $this->testmode == 'yes' ? $this->testurl : $this->liveurl;
-			
+
 			/**
 			 * PayPal PayFlow Gateway Request Params
 			 */
@@ -305,16 +305,16 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 					'trxtype'=>'S', 				// Required.  Indicates the type of transaction to perform.  Values are:  A = Authorization, B = Balance Inquiry, C = Credit, D = Delayed Capture, F = Voice Authorization, I = Inquiry, L = Data Upload, N = Duplicate Transaction, S = Sale, V = Void
 					'acct'=>$card_number, 				// Required for credit card transaction.  Credit card or purchase card number.
 					'expdate'=>$card_exp, 				// Required for credit card transaction.  Expiration date of the credit card.  Format:  MMYY
-					'amt'=>$order->get_total(), 					// Required.  Amount of the transaction.  Must have 2 decimal places. 
-					'currency'=>get_option('woocommerce_currency'), // 
+					'amt'=>$order->get_total(), 					// Required.  Amount of the transaction.  Must have 2 decimal places.
+					'currency'=>get_woocommerce_currency(), //
 					'dutyamt'=>'', 				//
 					'freightamt'=>'', 			//
 					'taxamt'=>'', 				//
-					'taxexempt'=>'', 			// 
+					'taxexempt'=>'', 			//
 					'comment1'=>$order->customer_note ? wptexturize($order->customer_note) : '', 			// Merchant-defined value for reporting and auditing purposes.  128 char max
 					'comment2'=>'', 			// Merchant-defined value for reporting and auditing purposes.  128 char max
 					'cvv2'=>$card_csc, 				// A code printed on the back of the card (or front for Amex)
-					'recurring'=>'', 			// Identifies the transaction as recurring.  One of the following values:  Y = transaction is recurring, N = transaction is not recurring. 
+					'recurring'=>'', 			// Identifies the transaction as recurring.  One of the following values:  Y = transaction is recurring, N = transaction is not recurring.
 					'swipe'=>'', 				// Required for card-present transactions.  Used to pass either Track 1 or Track 2, but not both.
 					'orderid'=>preg_replace("/[^0-9,.]/", "", $order->get_order_number()), // Checks for duplicate order.  If you pass orderid in a request and pass it again in the future the response returns DUPLICATE=2 along with the orderid
 					'orderdesc'=>'Order ' . $order->get_order_number() . ' on ' . get_bloginfo( 'name' ), //
@@ -325,22 +325,22 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 					'billtolastname'=>$order->billing_last_name, 		// Account holder's last name.
 					'billtostreet'=>$order->billing_address_1.' '.$order->billing_address_2, 		// The cardholder's street address (number and street name).  150 char max
 					'billtocity'=>$order->billing_city, 			// Bill to city.  45 char max
-					'billtostate'=>$order->billing_state, 			// Bill to state.  
+					'billtostate'=>$order->billing_state, 			// Bill to state.
 					'billtozip'=>$order->billing_postcode, 			// Account holder's 5 to 9 digit postal code.  9 char max.  No dashes, spaces, or non-numeric characters
 					'billtocountry'=>$order->billing_country, 		// Bill to Country.  3 letter country code.
-					'origid'=>'', 				// Required by some transaction types.  ID of the original transaction referenced.  The PNREF parameter returns this ID, and it appears as the Transaction ID in PayPal Manager reports.  
-					'custref'=>'', 				// 
-					'custcode'=>'', 			// 
-					'custip'=>$this->get_user_ip(), 				// 
-					'invnum'=>str_replace("#","",$order->get_order_number()), 				// 
-					'ponum'=>'', 				// 
+					'origid'=>'', 				// Required by some transaction types.  ID of the original transaction referenced.  The PNREF parameter returns this ID, and it appears as the Transaction ID in PayPal Manager reports.
+					'custref'=>'', 				//
+					'custcode'=>'', 			//
+					'custip'=>$this->get_user_ip(), 				//
+					'invnum'=>str_replace("#","",$order->get_order_number()), 				//
+					'ponum'=>'', 				//
 					'starttime'=>'', 			// For inquiry transaction when using CUSTREF to specify the transaction.
 					'endtime'=>'', 				// For inquiry transaction when using CUSTREF to specify the transaction.
 					'securetoken'=>'', 			// Required if using secure tokens.  A value the Payflow server created upon your request for storing transaction data.  32 char
-					'partialauth'=>'', 			// Required for partial authorizations.  Set to Y to submit a partial auth.    
+					'partialauth'=>'', 			// Required for partial authorizations.  Set to Y to submit a partial auth.
 					'authcode'=>'' 			// Rrequired for voice authorizations.  Returned only for approved voice authorization transactions.  AUTHCODE is the approval code received over the phone from the processing network.  6 char max
 					);
-			
+
 			/**
 			 * Shipping info
 			 */
@@ -354,7 +354,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
                 $PayPalRequestData['SHIPTOCOUNTRY']     = $order->shipping_country;
                 $PayPalRequestData['SHIPTOZIP']         = $order->shipping_postcode;
             }
-					
+
 			/* Send Item details */
             $item_loop = 0;
             if(sizeof($order->get_items()) > 0)
@@ -455,7 +455,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
                     $PayPalRequestData['FREIGHTAMT'] = $shipping;
                 }
             }
-			
+
 			/**
 			 * Add custom Woo cart fees as line items
 			 */
@@ -466,14 +466,14 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 				$PayPalRequestData['L_AMT' . $item_loop ]		= number_format($fee->amount,2,'.','');
 				$PayPalRequestData['L_QTY' . $item_loop ]		= 1;
 				$item_loop++;
-				
+
 				$ITEMAMT += $fee->amount*$Item['qty'];
 			}
-			
+
 			$PayPalRequestData['ITEMAMT'] = number_format($ITEMAMT,2,'.','');
-			
+
 			/**
-			 * Woo's original extension wasn't sending the request with 
+			 * Woo's original extension wasn't sending the request with
 			 * character count like it's supposed to.  This was added
 			 * to fix that, but now that we're using my library it's
 			 * already handled correctly so this won't be necessary.
@@ -482,12 +482,12 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
                 $send_data[]= $key."[".strlen($value)."]=$value";
             }
             $send_data = implode("&", $send_data);*/
-			
+
 			/**
 			 * Pass data to to the class and store the $PayPalResult
 			 */
 			$PayPalResult = $PayPal->ProcessTransaction($PayPalRequestData);
-			
+
 			/**
 			 * Log results
 			 */
@@ -496,7 +496,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 				$this->add_log('PayFlow Endpoint: '.$PayPal->APIEndPoint);
             	$this->add_log(print_r($PayPalResult,true));
 			}
-			
+
 			/**
 			 * Error check
 			 */
@@ -504,15 +504,15 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 			{
                 throw new Exception(__('Empty PayPal response.', 'paypal-for-woocommerce'));
 			}
-			
-			/** 
+
+			/**
 			 * More logs
 			 */
 			if($this->debug)
 			{
 				$this->add_log(add_query_arg('key',$order->order_key,add_query_arg('order',$order->id,get_permalink(woocommerce_get_page_id('thanks')))));
 			}
-			
+
 			/**
 			 * Check for errors or fraud filter warnings and proceed accordingly.
 			 */
@@ -546,7 +546,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 			else
 			{
 				$order->update_status( 'failed', __('PayPal Pro payment failed. Payment was rejected due to an error: ', 'paypal-for-woocommerce' ) . '(' . $PayPalResult['RESULT'] . ') ' . '"' . $PayPalResult['RESPMSG'] . '"' );
-				
+
 				// Generate error message based on Error Display Type setting
 				if($this->error_display_type == 'detailed')
 				{
@@ -556,7 +556,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 				{
                 	wc_add_notice( __( 'Payment error:', 'paypal-for-woocommerce' ) . ' There was a problem processing your payment.  Please try another method.', "error" );
 				}
-				
+
                 return;
 
             }
@@ -565,7 +565,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 		{
             wc_add_notice( __('Connection error:', 'paypal-for-woocommerce' ) . ': "' . $e->getMessage() . '"', "error");
             return;
-        }	
+        }
 	}
 
 	/**


### PR DESCRIPTION
Replaced all `get_option('woocommerce_currency')` with `get_woocommerce_currency()`. The latter will return the currency that is active when an order is being paid. In most cases, it will match the base currency, and it will also work with multi-currency plugins such as the Currency Switcher (http://bit.ly/1rVC5S1ac).
