### PR TITLE
Fixed logic used to retrieve the currency

### DIFF
--- a/classes/wc-gateway-paypal-express-angelleye.php
+++ b/classes/wc-gateway-paypal-express-angelleye.php
@@ -987,7 +987,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         update_post_meta( $order_id, '_customer_user',    ( int ) get_current_user_id() );
         update_post_meta( $order_id, '_order_items',    $order_items );
         update_post_meta( $order_id, '_order_taxes',    $order_taxes );
-        update_post_meta( $order_id, '_order_currency',   get_option( 'woocommerce_currency' ) );
+        update_post_meta( $order_id, '_order_currency',   get_woocommerce_currency() );
         update_post_meta( $order_id, '_prices_include_tax',  get_option( 'woocommerce_prices_include_tax' ) );
         // Order status
         wp_set_object_terms( $order_id, 'pending', 'shop_order_status' );
@@ -1140,7 +1140,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         $Payments = array();
         $Payment = array(
             'amt' => number_format(WC()->cart->total,2,'.',''), 							// Required.  The total cost of the transaction to the customer.  If shipping cost and tax charges are known, include them in this value.  If not, this value should be the current sub-total of the order.
-            'currencycode' => get_option('woocommerce_currency'), 					// A three-character currency code.  Default is USD.
+            'currencycode' => get_woocommerce_currency(), 					// A three-character currency code.  Default is USD.
             'shippingamt' => number_format($shipping,2,'.',''), 					// Total shipping costs for this order.  If you specify SHIPPINGAMT you mut also specify a value for ITEMAMT.
             'shippingdiscamt' => '', 				// Shipping discount for this order, specified as a negative number.
             'insuranceamt' => '', 					// Total shipping insurance costs for this order.
@@ -1528,7 +1528,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
         $Payments = array();
         $Payment = array(
             'amt' => number_format($FinalPaymentAmt,2,'.',''), 							// Required.  The total cost of the transaction to the customer.  If shipping cost and tax charges are known, include them in this value.  If not, this value should be the current sub-total of the order.
-            'currencycode' => get_option('woocommerce_currency'), 					// A three-character currency code.  Default is USD.
+            'currencycode' => get_woocommerce_currency(), 					// A three-character currency code.  Default is USD.
             'shippingdiscamt' => '', 				// Total shipping discount for this order, specified as a negative number.
             'insuranceoptionoffered' => '', 		// If true, the insurance drop-down on the PayPal review page displays the string 'Yes' and the insurance amount.  If true, the total shipping insurance for this order must be a positive number.
             'handlingamt' => '', 					// Total handling costs for this order.  If you specify HANDLINGAMT you mut also specify a value for ITEMAMT.

--- a/classes/wc-gateway-paypal-pro-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-angelleye.php
@@ -303,7 +303,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
         if ($this->enabled=="yes") :
             if ( $this->testmode == "no" && get_option('woocommerce_force_ssl_checkout')=='no' && !class_exists( 'WordPressHTTPS' ) ) return false;
             // Currency check
-            if ( ! in_array( get_option( 'woocommerce_currency' ), apply_filters( 'woocommerce_paypal_pro_allowed_currencies', array( 'AUD', 'CAD', 'CZK', 'DKK', 'EUR', 'HUF', 'JPY', 'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD' ) ) ) ) return false;
+            if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_paypal_pro_allowed_currencies', array( 'AUD', 'CAD', 'CZK', 'DKK', 'EUR', 'HUF', 'JPY', 'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD' ) ) ) ) return false;
             // Required fields check
             if (!$this->api_username || !$this->api_password || !$this->api_signature) return false;
             return isset($this->avaiable_card_types[WC()->countries->get_base_country()]);
@@ -461,7 +461,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
             // Standard cmpi_lookup fields
             $centinelClient->add('OrderNumber', $order_id);
             $centinelClient->add('Amount', $order->order_total * 100 );
-            $centinelClient->add('CurrencyCode', $this->iso4217[get_option('woocommerce_currency')]);
+            $centinelClient->add('CurrencyCode', $this->iso4217[get_woocommerce_currency()]);
             $centinelClient->add('TransactionMode', 'S');
             // Items
             $item_loop = 0;
@@ -717,7 +717,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway {
 							
 		$PaymentDetails = array(
 								'amt' => $order->get_total(), 							// Required.  Total amount of order, including shipping, handling, and tax.  
-								'currencycode' => get_option('woocommerce_currency'), 					// Required.  Three-letter currency code.  Default is USD.
+								'currencycode' => get_woocommerce_currency(), 					// Required.  Three-letter currency code.  Default is USD.
 								'insuranceamt' => '', 					// Total shipping insurance costs for this order.  
 								'shipdiscamt' => '', 					// Shipping discount for the order, specified as a negative number.
 								'handlingamt' => '', 					// Total handling costs for the order.  If you specify handlingamt, you must also specify itemamt.

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -211,7 +211,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 				return false;
 
 			// Currency check
-			if ( ! in_array( get_option('woocommerce_currency'), $this->allowed_currencies ) )
+			if ( ! in_array( get_woocommerce_currency(), $this->allowed_currencies ) )
 				return false;
 
 			// Required fields check
@@ -319,7 +319,7 @@ for the Payflow SDK. If you purchased your account directly from PayPal, use Pay
 					'acct'=>$card_number, 				// Required for credit card transaction.  Credit card or purchase card number.
 					'expdate'=>$card_exp, 				// Required for credit card transaction.  Expiration date of the credit card.  Format:  MMYY
 					'amt'=>$order->get_total(), 					// Required.  Amount of the transaction.  Must have 2 decimal places. 
-					'currency'=>get_option('woocommerce_currency'), // 
+					'currency'=>get_woocommerce_currency(), // 
 					'dutyamt'=>'', 				//
 					'freightamt'=>'', 			//
 					'taxamt'=>'', 				//


### PR DESCRIPTION
- Replaced all get_option('woocommerce_currency') with get_woocommerce_currency(). The latter will return the currency that is active when an order is being paid. In most cases, it will match the base currency, and it will also work with multi-currency plugins such as the Currency Switcher (http://bit.ly/1rVC5S1ac).
