### PR TITLE
Added jQuery triggers to fire when event listeners are attached

### DIFF
--- a/assets/js/angelleye-frontend.js
+++ b/assets/js/angelleye-frontend.js
@@ -40,4 +40,9 @@ jQuery(document).ready(function ($){
             return true;
         });
     }
+		// Let themes/plugins override our event handlers
+		// NOTE: The jQuery .on() function attached to listen to the event below MUST
+		// be included somewhere on the page itself...so it gets registered before we load
+		// asyncronous JavaScript resources. Otherwise your function listening might not fire.
+		$(".paypal_checkout_button").trigger('angelleye_paypal_checkout_button_js_loaded');
 });

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -161,4 +161,9 @@ jQuery(function($) {
 		$('body').trigger('update_checkout');
 	})
 
+	// Let themes/plugins override our event handlers
+	// NOTE: The jQuery .on() function attached to listen to the event below MUST
+	// be included somewhere on the page itself...so it gets registered before we load
+	// asyncronous JavaScript resources. Otherwise your function listening might not fire.
+	$('form.angelleye_checkout').trigger('angelleye_paypal_form_checkout_js_loaded');
 });


### PR DESCRIPTION
Added 'angelleye_paypal_form_checkout_js_loaded' and 'angelleye_paypal_checkout_button_js_loaded' jQuery triggers.

Might be useful for themes/plugins that need to override the event-listener functions. There still might be lots of places that might benefit from triggers, but just these two are a lot of help since we wont have to modify any javascript, we can just redefine our own.

Note: jQuery triggers bubble up the DOM, so there is no need to attach the event listeners directly to the elements "`.paypal_checkout_button`" and "`form.angelleye_checkout`". You can attach them directly in `document.body`.