### PR TITLE
Auto cancellation & refund based on transaction Seller Protection response

### DIFF
--- a/i18n/languages/paypal-for-woocommerce.pot
+++ b/i18n/languages/paypal-for-woocommerce.pot
@@ -728,6 +728,55 @@ msgstr ""
 msgid "Pay with Credit Card"
 msgstr ""
 
+#: classes/wc-gateway-paypal-express-angelleye.php:498
+msgid "Cancel/Refund orders that: "
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:500
+msgid ""
+"Allows you to cancel and refund orders that do not meet PayPal's "
+"Seller Protection criteria"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:503
+msgid "Do *not* have PayPal Seller Protection"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:504
+msgid "Do *not* have PayPal Unauthorized Payment Protection"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:505
+msgid "Do not cancel any orders"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:1207
+msgid ""
+"Transaction did not meet our Seller Protection requirements. Cancelling and "
+"refunding order."
+""
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:1209
+msgid ""
+"PayPal Express Checkout payment declined due to our Seller Protection "
+"Settings"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:1209
+msgid "Order #"
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:1215
+msgid "There was a problem processing your order. Please contact customer support."
+msgstr ""
+
+#: classes/wc-gateway-paypal-express-angelleye.php:1217
+msgid ""
+"Thank you for your recent order. Unfortunately it has been cancelled and refunded. "
+"Please contact our customer support team."
+msgstr ""
+
 #: classes/wc-gateway-paypal-plus-angelleye.php:26
 #: classes/wc-gateway-paypal-plus-angelleye.php:121
 #: classes/wc-gateway-paypal-plus-angelleye.php:161


### PR DESCRIPTION
This feature is to allow the merchant to automatically decline transactions that either have no seller protection or partial protection (partial protection would be for "item not received" PayPal cases, per: `ProtectionEligibility` response field from https://developer.paypal.com/docs/classic/api/merchant/DoExpressCheckoutPayment_API_Operation_SOAP/#paymentinfotype-fields and https://developer.paypal.com/docs/classic/api/merchant/GetTransactionDetails_API_Operation_NVP/ ).

The setting is exposed to the gateway's settings page, where the merchant is able to select what kind of protection they would like to enforce (e.g. if they are using woocommerce to ship out tangible goods or perhaps).

It seems I was a little behind on the current protocol, since 64.4 we should use `ProtectionEligibilityType` instead of `ProtectionEligibility` (which makes sense, the responses easier to read plain-english). If you guys think that this can be used, I can update the response checks with another pull request. For now, it seems PayPal will not be deprecating the `ProtectionEligibility` field that I am currently using since it still might be widely used...and it serves the same purpose as `ProtectionEligibilityType`.

I also manually added the translation strings to "paypal-for-woocommerce.pot" for consistency, but I am sure one of you here can generate them on the fly.