### PR TITLE
change "express_checkout" to "expresscheckout", to align with the PAY…

### DIFF
--- a/classes/wc-gateway-paypal-express-angelleye.php
+++ b/classes/wc-gateway-paypal-express-angelleye.php
@@ -1366,7 +1366,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 					break;
 				}
 
-				if ( ! in_array( strtolower( $result['PAYMENTINFO_0_TRANSACTIONTYPE'] ), array( 'cart', 'instant', 'express_checkout', 'web_accept', 'masspay', 'send_money' ) ) ) {
+				if ( ! in_array( strtolower( $result['PAYMENTINFO_0_TRANSACTIONTYPE'] ), array( 'cart', 'instant', 'expresscheckout', 'web_accept', 'masspay', 'send_money' ) ) ) {
 					break;
 				}
 
@@ -1377,7 +1377,7 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
 				break;
 			case 'pending' :
 
-                            if ( ! in_array( strtolower( $result['PAYMENTINFO_0_TRANSACTIONTYPE'] ), array( 'cart', 'instant', 'express_checkout', 'web_accept', 'masspay', 'send_money' ) ) ) {
+                            if ( ! in_array( strtolower( $result['PAYMENTINFO_0_TRANSACTIONTYPE'] ), array( 'cart', 'instant', 'expresscheckout', 'web_accept', 'masspay', 'send_money' ) ) ) {
 					break;
 				}
 


### PR DESCRIPTION
Orders with PayPal Express payments were hanging at "Pending Payment", due to the PAYMENTINFO_0_TRANSACTIONTYPE check against "express_checkout" instead of "expresscheckout" which is what the PP API responds with.