### PR TITLE
wrap item amt in number_format

### DIFF
--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -800,7 +800,7 @@ if(!class_exists('AngellEYE_Gateway_Paypal')){
                     $Item = array(
                         'name' => $item['name'], // Item name. 127 char max.
                         'desc' => '', // Item description. 127 char max.
-                        'amt' => self::round( $item['line_subtotal'] / $qty), // Cost of item.
+                        'amt' => self::number_format(self::round( $item['line_subtotal'] / $qty), 2, '.', ''), // Cost of item.
                         'number' => $sku, // Item number.  127 char max.
                         'qty' => $qty, // Item qty on order.  Any positive integer.
                     );


### PR DESCRIPTION
because round function can be localized it's safer to wrap the result into number_format