### PR TITLE
Updated to match the default alert behavior.

### DIFF
--- a/assets/js/angelleye-frontend.js
+++ b/assets/js/angelleye-frontend.js
@@ -1,18 +1,20 @@
 jQuery(document).ready(function ($){
     if (angelleye_frontend.is_product == "yes"){
         jQuery("#paypal_ec_button_product input, input.single_variation_wrap_angelleye").click(function(){
-            $( '.cart' ).block({
-            message: null,
-            overlayCSS: {
-            background: '#fff',
-            opacity: 0.6
-            }
-            });
-            var angelleye_action = $(this).data('action');
-            $('form.cart').attr( 'action', angelleye_action );
-            $(this).attr('disabled', 'disabled');
-            $('form.cart').submit();
-            return false;
+       		if (!$('.woocommerce-variation-add-to-cart').hasClass('woocommerce-variation-add-to-cart-disabled')) {
+	            $( '.cart' ).block({
+	            message: null,
+	            overlayCSS: {
+	            background: '#fff',
+	            opacity: 0.6
+	            }
+	            });
+	            var angelleye_action = $(this).data('action');
+	            $('form.cart').attr( 'action', angelleye_action );
+	            $(this).attr('disabled', 'disabled');
+	            $('form.cart').submit();
+	            return false;
+       		}
         });
     }
     if (angelleye_frontend.is_cart == "yes"){


### PR DESCRIPTION
WooCommerce triggers a JavaScript alert when a user tries to add a Variable Product without selecting all the attributes of the product. This check simply ensures that the condition is met.