### PR TITLE
PHP 7.0 Compatibility

### DIFF
--- a/classes/lib/CentinelClient.php
+++ b/classes/lib/CentinelClient.php
@@ -119,8 +119,8 @@
             $this->response = array();
             
             if($payload != "" && $payload != null) {
-                $parts = split("&", $payload);
-                $hashPart =  split("=", $parts[count($parts)-1]);
+                $parts = explode("&", $payload);
+                $hashPart =  explode("=", $parts[count($parts)-1]);
                 
                 $origPayload = preg_replace("/\&".$parts[count($parts)-1]."/", '', $payload ).$transactionPwd; 
                 $payloadHash = $hashPart[1];
@@ -132,7 +132,7 @@
                 } // end if
 
                 for($i = 0; $i < count($parts); $i++) {
-                    $kv = split("=", $parts[$i]);   
+                    $kv = explode("=", $parts[$i]);   
                     $key = $kv[0];
                     $value = $kv[1];
                     if("ErrorNo" == $key && isset($this->response["ErrorNo"]) ) {


### PR DESCRIPTION
split function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0. 
