### PR TITLE
Added confirm on capture and update order total amount without save o…

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -841,6 +841,36 @@ class AngellEYE_Utility {
                 <?php $this->angelleye_express_checkout_transaction_capture_dropdownbox($post->ID); ?>
                 <input type="submit" id="angelleye_payment_submit_button" value="Submit" name="save" class="button button-primary" style="display: none">
                 <br/><br/><br/>
+                <script>
+                    //Asking confirm for the capture
+                    jQuery('#angelleye_payment_submit_button').on('click', function(){
+                        var selected = jQuery('#angelleye_payment_action option:checked').val();
+                        if(selected == 'DoCapture') {
+                            var amt = jQuery('.angelleye_order_action_table:first tr:first td:last').text();
+
+                            return confirm('You are capuring: ' + amt + '. Are you sure?');
+                        }
+                    })
+
+                    MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+                    var observer = new MutationObserver(function(mutations, observer) {
+                        for(var i = 0, len = mutations.length; i < len; i++) {
+                            //Updating the total order action table field
+                            if(mutations[i].target.className == 'inside' && mutations[i].addedNodes.length > 0) {
+                                var new_amt_with_curr = jQuery('.wc-order-refund-items .wc-order-totals tr td.total .amount:last').text();
+                                jQuery('.angelleye_order_action_table:first tr:first td:last').text(new_amt_with_curr);
+                            }
+                        }
+                    });
+
+                    //Setting an observer to know about total new total amount
+                    jQuery(document).ready(function () {
+                        var target = document.getElementById('woocommerce-order-items').getElementsByClassName('inside')[0];
+                        observer.observe(target, {
+                            childList: true,
+                        });
+                    });
+                </script>
                 <?php
             }
             

--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -851,7 +851,7 @@ class AngellEYE_Utility {
                         if(selected == 'DoCapture') {
                             var amt = $('.angelleye_order_action_table:first tr:first td:last').text();
 
-                            return confirm('You are capuring: ' + amt + '. Are you sure?');
+                            return confirm('You are capturing: ' + amt + '. Are you sure?');
                         }
                     })
 

--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -854,10 +854,14 @@ class AngellEYE_Utility {
 
                     MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
                     var observer = new MutationObserver(function(mutations, observer) {
+                        var currency_symbol = window.woocommerce_admin_meta_boxes.currency_format_symbol;
+                        
                         for(var i = 0, len = mutations.length; i < len; i++) {
                             //Updating the total order action table field
                             if(mutations[i].target.className == 'inside' && mutations[i].addedNodes.length > 0) {
                                 var new_amt_with_curr = jQuery('.wc-order-refund-items .wc-order-totals tr td.total .amount:last').text();
+                                //Adjusting price with paypal-for-woocommerce amount format
+                                new_amt_with_curr = currency_symbol + new_amt_with_curr.replace(currency_symbol, '');
                                 jQuery('.angelleye_order_action_table:first tr:first td:last').text(new_amt_with_curr);
                             }
                         }

--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -842,11 +842,14 @@ class AngellEYE_Utility {
                 <input type="submit" id="angelleye_payment_submit_button" value="Submit" name="save" class="button button-primary" style="display: none">
                 <br/><br/><br/>
                 <script>
+                (function($) {
+                    "use strict";
+                    
                     //Asking confirm for the capture
-                    jQuery('#angelleye_payment_submit_button').on('click', function(){
-                        var selected = jQuery('#angelleye_payment_action option:checked').val();
+                    $('#angelleye_payment_submit_button').on('click', function(){
+                        var selected = $('#angelleye_payment_action option:checked').val();
                         if(selected == 'DoCapture') {
-                            var amt = jQuery('.angelleye_order_action_table:first tr:first td:last').text();
+                            var amt = $('.angelleye_order_action_table:first tr:first td:last').text();
 
                             return confirm('You are capuring: ' + amt + '. Are you sure?');
                         }
@@ -859,21 +862,22 @@ class AngellEYE_Utility {
                         for(var i = 0, len = mutations.length; i < len; i++) {
                             //Updating the total order action table field
                             if(mutations[i].target.className == 'inside' && mutations[i].addedNodes.length > 0) {
-                                var new_amt_with_curr = jQuery('.wc-order-refund-items .wc-order-totals tr td.total .amount:last').text();
+                                var new_amt_with_curr = $('.wc-order-refund-items .wc-order-totals tr td.total .amount:last').text();
                                 //Adjusting price with paypal-for-woocommerce amount format
                                 new_amt_with_curr = currency_symbol + new_amt_with_curr.replace(currency_symbol, '');
-                                jQuery('.angelleye_order_action_table:first tr:first td:last').text(new_amt_with_curr);
+                                $('.angelleye_order_action_table:first tr:first td:last').text(new_amt_with_curr);
                             }
                         }
                     });
 
                     //Setting an observer to know about total new total amount
-                    jQuery(document).ready(function () {
+                    $(document).ready(function () {
                         var target = document.getElementById('woocommerce-order-items').getElementsByClassName('inside')[0];
                         observer.observe(target, {
                             childList: true,
                         });
                     });
+                })(jQuery);
                 </script>
                 <?php
             }


### PR DESCRIPTION
The action to capture the order is the most important action in the authorize/capture flow. So i have added to that action a js confirm that ask if the amount is correct.

To do that i need to have the value in "total order" field in the table "angelleye_order_action_table" updated each woocommerce order operation otherwise i show a bad value.

So i have added an observer to update this value at each operation on the div woocommerce-order-items. 