### PR TITLE
Update paypal_transaction post type arguments

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -957,23 +957,8 @@ class AngellEYE_Utility {
             ),
             'description' => __('This is where you can add new PayPal Transaction to your store.', 'paypal-for-woocommerce'),
             'public' => false,
-            'show_ui' => false,
-            'capability_type' => 'post',
-            'capabilities' => array(
-                'create_posts' => false, // Removes support for the "Add New" function
-            ),
-            'map_meta_cap' => true,
-            'publicly_queryable' => true,
-            'exclude_from_search' => false,
-            'hierarchical' => false, // Hierarchical causes memory issues - WP loads all records!
-            'rewrite' => array('slug' => 'paypal_ipn'),
-            'query_var' => true,
-            'supports' => array('', ''),
-            'has_archive' => true,
-            'show_in_nav_menus' => FALSE
-                        )
-                )
-        );
+            'query_var' => false,
+        ) ) );
     }
 
     public function angelleye_paypal_for_woocommerce_order_action_meta_box($post_type, $post) {


### PR DESCRIPTION
The `paypal_transaction` post type is being registered with a lot of arguments. Arguments which aren't necessary because their default values are the same, or their default or other values fit the post type better. 

I've changed the following

| argument            	| old value                         	| new value                                                       	| reason                                                                                                  	|
|---------------------	|-----------------------------------	|-----------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------	|
| show_ui             	| `false`                           	| `false` (default)                                               	| default value is the same                                                                               	|
| capability_type     	| `'post'`                          	| `'post'` (default)                                              	| default value is the same                                                                               	|
| capabilities        	| `array( 'create_posts' => false)` 	| `array()` (default)                                             	| Its value doesn't seem to matter in the case of paypal_transactions. Just leave it as its default value 	|
| map_meta_cap        	| `true`                            	| `null` (default) which translates to `true`                     	| default value is the same                                                                               	|
| publicly_queryable  	| `true`                            	| `false` (default)                                               	| Transactions should not be publicly accessible                                                          	|
| exclude_from_search 	| `false`                           	| `false` (default)                                               	| default value is the same                                                                               	|
| hierarchical        	| `false`                           	| `false` (default)                                               	| default value is the same                                                                               	|
| rewrite             	| `array('slug' => 'paypal_ip')`    	| `true` (default)                                                	| Its value doesn't seem to matter in the case of paypal_transactions. Just leave it as its default value 	|
| query_var           	| `true`                            	| `false`                                                         	| Transactions should not be publicly accessible                                                          	|
| supports            	| `array('', '')`                   	| `array()` (default) which translates to `( 'title', 'editor' )` 	| Its value doesn't seem to matter in the case of paypal_transactions. Just leave it as its default value 	|
| has_archive         	| `true`                            	| `false` (default)                                               	| Transactions should not be publicly accessible, and thus shouldn't have an archive                      	|
| show_in_nav_menus   	| `FALSE`                           	| `false` (default)                                               	| default value is the same                                                                               	|