### PR TITLE
get_state_code() should return state code instead of state name

### DIFF
--- a/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-request-angelleye.php
+++ b/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-request-angelleye.php
@@ -1092,8 +1092,10 @@ class WC_Gateway_PayPal_Express_Request_AngellEYE {
             return $state;
         }
         $states = WC()->countries->get_states($cc);
-        if (isset($states[$state])) {
-            return $states[$state];
+        foreach ($states as $state_code => $state_value) {
+            if (strtolower($state_code) == strtolower($state)) {
+                return $state_code;
+            }
         }
         return $state;
     }


### PR DESCRIPTION
I encountered this problem when I realize PayPal returns `Qld` for Queensland, Australia. While in WooCommerce, the valid state code is `QLD`, get_state_code('AU', 'Qld') will return 'Qld'.
Also, I notice get_state_code() should return the code instead of the name, even for non-US countries.