### PR TITLE
PFW-189 Passed 3rd argument as order object in 3 do_actions 'woocommerce_checkout_order_processed'

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -1297,7 +1297,7 @@ class AngellEYE_Utility {
             if ($order->get_total() - $order->get_total_refunded() <= $this->total_Completed_DoAuthorization && $this->total_Pending_DoAuthorization == 0) {
                 do_action('woocommerce_order_status_pending_to_processing', $order_id);
                 $order->payment_complete($_first_transaction_id);
-                do_action('woocommerce_checkout_order_processed', $order_id, $posted = array());
+                do_action('woocommerce_checkout_order_processed', $order_id, $posted = array(), $order);
             }
         }
     }

--- a/classes/wc-gateway-paypal-express-angelleye.php
+++ b/classes/wc-gateway-paypal-express-angelleye.php
@@ -1463,13 +1463,18 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                             }
                             $this->angelleye_check_cart_items();
                             $order_id = WC()->checkout()->create_order($this->posted);
+
                             if (is_wp_error($order_id)) {
                                 throw new Exception($order_id->get_error_message());
                             }
+
+                            /** Creating Order Object for fresh created order */
+                            $order = wc_get_order($order_id);
+
                             if ( ! is_user_logged_in() && WC()->checkout->is_registration_required($order_id) ) {
                                 $paypal_express_request->angelleye_process_customer($order_id);
                             }
-                            do_action('woocommerce_checkout_order_processed', $order_id, $this->posted);
+                            do_action('woocommerce_checkout_order_processed', $order_id, $this->posted, $order);
                         } else {
                             $_POST = WC()->session->get( 'post_data' );
                             $this->posted = WC()->session->get( 'post_data' );
@@ -1513,12 +1518,18 @@ class WC_Gateway_PayPal_Express_AngellEYE extends WC_Payment_Gateway {
                             if (is_wp_error($order_id)) {
                                 throw new Exception($order_id->get_error_message());
                             }
+
+                            /** Creating Order Object for fresh created order */
+                            $order = wc_get_order($order_id);
+
                             if ( ! is_user_logged_in() && WC()->checkout->is_registration_required() ) {
                                 $paypal_express_request->angelleye_process_customer($order_id);
                             }
-                            do_action('woocommerce_checkout_order_processed', $order_id, $this->posted);
+                            do_action('woocommerce_checkout_order_processed', $order_id, $this->posted, $order);
                         }
-                        $order = wc_get_order($order_id);
+                        if(!$order instanceof WC_Order) {
+                            $order = wc_get_order($order_id);
+                        }
                         $post_data = WC()->session->get('post_data');
                         if ($this->billing_address && empty($post_data)) {
                             $paypal_express_checkout = WC()->session->get( 'paypal_express_checkout' );


### PR DESCRIPTION
Hello Angelleye Team,

### Problem:

3 do_actions with handle 'woocommerce_checkout_order_processed' used in 2 files
- paypal-woocommerce/classes/wc-gateway-paypal-express-angelleye.php
- paypal-woocommerce/angelleye-includes/angelleye-utility.php

order_id and posted_data were passed as 2 arguments.

In WooCommerce, same do_action is used with 3 arguments 'order_id', 'posted_data' and 'order_object'
https://i.imgur.com/hoojW8G.png

Plugin devs use that hook (as this is a common hook which runs on process_checkout) and as the 3rd argument is not present, it results in PHP fatal error.

### Changes proposed in this Pull Request:

Added order_object as the 3rd argument at all 3 positions.

### How we came to know:

We have a plugin called '[Upstroke: WooCommerce One Click Upsell](https://buildwoofunnels.com/woocommerce-one-click-upsells-upstroke/)', Where we do upsells after purchase. We have many clients which use angelleye PayPal express payment gateway.
Some on latest PHP i.e. 7.2.7
They faced the error on their setup. That's why we came to know about the problem.


Hope if this pull request ok. You will release a patch release soon. As this might breaking the User's cart.

Let us know if any changes.