### PR TITLE
Adds Invoice ID to DoCapture calls

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -405,6 +405,13 @@ class AngellEYE_Utility {
             'CURRENCYCODE' => version_compare(WC_VERSION, '3.0', '<') ? $order->get_order_currency() : $order->get_currency(),
             'COMPLETETYPE' => 'NotComplete',
         );
+
+        $payment_gateway = wc_get_payment_gateway_by_order( $order );
+        if ( $payment_gateway && isset( $payment_gateway->invoice_id_prefix ) ) {
+            $invnum = $payment_gateway->invoice_id_prefix . preg_replace("/[^a-zA-Z0-9]/", "", str_replace("#", "", $order->get_order_number()));
+            $DataArray['INVNUM'] = $invnum;
+        }
+
         $PayPalRequest = array(
             'DCFields' => $DataArray
         );


### PR DESCRIPTION
Since July 26th Paypal has been refusing our captures of authorized Paypal Express payments with error code 10003 and the message: "Invoice ID is required".

Though the [documentation](https://developer.paypal.com/docs/classic/api/merchant/DoCapture_API_Operation_NVP/) still doesn't indicate that Invoice IDs are required on DoCapture calls, we found that adding the `INVNUM` parameter fixes the issue.

This PR looks for the invoice id prefix on the payment gateway and adds the INVNUM accordingly.

* I have only tested this with PayPal Express. Maybe this change should be limited to PPEC only?
* The invoice ID is generated on the fly. If the user changes the invoice ID prefix between authorizatino & capture, this fix will generate the wrong Invoice ID. Should the Invoice ID be stored as post meta?