### PR TITLE
Bugfix/fix ctype digit validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ temp/
 /classes/lib/angelleye/paypal-php-library/documentation/_notes/
 /classes/lib/angelleye/paypal-php-library/includes/_notes/
 /classes/lib/angelleye/paypal-php-library/templates/_notes/
+.idea

--- a/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php
+++ b/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php
@@ -85,9 +85,9 @@ class WC_Gateway_PayPal_Credit_Card_Rest_AngellEYE extends WC_Payment_Gateway_CC
             <h3><?php echo (!empty($this->method_title) ) ? $this->method_title : __('Settings', 'paypal-for-woocommerce'); ?></h3>
             <?php echo (!empty($this->method_description) ) ? wpautop($this->method_description) : ''; ?>
             <table class="form-table">
-            <?php 
+            <?php
                 if(version_compare(WC_VERSION,'2.6','<')) {
-                    AngellEYE_Utility::woo_compatibility_notice();    
+                    AngellEYE_Utility::woo_compatibility_notice();
                 } elseif (version_compare(phpversion(), '5.3.0', '<')) {
                     echo '<div class="error angelleye-notice" style="display:none;"><div class="angelleye-notice-logo"><span></span></div><div class="angelleye-notice-message">' . __('PayPal for WooCommerce requires PHP version 5.3.0 or higher.','paypal-for-woocommerce') . '</div></div>';
                 } else {
@@ -161,7 +161,7 @@ class WC_Gateway_PayPal_Credit_Card_Rest_AngellEYE extends WC_Payment_Gateway_CC
         }
         do_action('payment_fields_saved_payment_methods', $this);
     }
-    
+
     public function save_payment_method_checkbox() {
         printf(
                 '<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
@@ -198,19 +198,31 @@ class WC_Gateway_PayPal_Credit_Card_Rest_AngellEYE extends WC_Payment_Gateway_CC
                     return true;
                 }
             }
+
             $card = $this->paypal_rest_api->get_posted_card();
+
             if (empty($card->exp_month) || empty($card->exp_year)) {
                 throw new Exception(__('Card expiration date is invalid', 'woocommerce-gateway-paypal-pro'));
             }
-            if (!ctype_digit($card->cvc)) {
+
+            if (!ctype_digit((string) $card->cvc)) {
                 throw new Exception(__('Card security code is invalid (only digits are allowed)', 'woocommerce-gateway-paypal-pro'));
             }
-            if (!ctype_digit($card->exp_month) || !ctype_digit($card->exp_year) || $card->exp_month > 12 || $card->exp_month < 1 || $card->exp_year < date('y')) {
+
+            if (
+                    !ctype_digit((string) $card->exp_month) ||
+                    !ctype_digit((string) $card->exp_year) ||
+                    $card->exp_month > 12 ||
+                    $card->exp_month < 1 ||
+                    $card->exp_year < date('y')
+            ) {
                 throw new Exception(__('Card expiration date is invalid', 'woocommerce-gateway-paypal-pro'));
             }
-            if (empty($card->number) || !ctype_digit($card->number)) {
+
+            if (empty($card->number) || !ctype_digit((string) $card->number)) {
                 throw new Exception(__('Card number is invalid', 'woocommerce-gateway-paypal-pro'));
             }
+
             return true;
         } catch (Exception $e) {
             wc_add_notice($e->getMessage(), 'error');
@@ -355,7 +367,7 @@ class WC_Gateway_PayPal_Credit_Card_Rest_AngellEYE extends WC_Payment_Gateway_CC
         }
         return $settings;
     }
-    
+
     public function angelleye_reload_gateway_credentials_for_woo_subscription_renewal_order($order) {
         if( $this->testmode == false ) {
             $order_id = version_compare(WC_VERSION, '3.0', '<') ? $order->id : $order->get_id();
@@ -370,7 +382,7 @@ class WC_Gateway_PayPal_Credit_Card_Rest_AngellEYE extends WC_Payment_Gateway_CC
                             $this->rest_client_id = $this->get_option('rest_client_id_sandbox', false);
                             $this->rest_secret_id = $this->get_option('rest_secret_id_sandbox', false);
                         }
-                    }        
+                    }
                 }
             }
         }

--- a/classes/wc-gateway-paypal-pro-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-angelleye.php
@@ -87,17 +87,17 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         }
         $this->invoice_id_prefix = $this->get_option('invoice_id_prefix');
         $this->error_email_notify = $this->get_option('error_email_notify');
-        $this->error_display_type = $this->get_option('error_display_type'); 
+        $this->error_display_type = $this->get_option('error_display_type');
         //$this->enable_3dsecure = 'yes' === $this->get_option('enable_3dsecure', 'no');
         $this->enable_3dsecure = false;
         $this->liability_shift = 'yes' === $this->get_option('liability_shift', 'no');
-        $this->debug = 'yes' === $this->get_option('debug', 'no'); 
+        $this->debug = 'yes' === $this->get_option('debug', 'no');
         $this->payment_action = $this->get_option('payment_action', 'Sale');
         $this->send_items = 'yes' === $this->get_option('send_items', 'yes');
         $this->enable_notifyurl = $this->get_option('enable_notifyurl', 'no');
         $this->is_encrypt = $this->get_option('is_encrypt', 'no');
         $this->softdescriptor = $this->get_option('softdescriptor', '');
-        $this->avs_cvv2_result_admin_email = 'yes' === $this->get_option('avs_cvv2_result_admin_email', 'no'); 
+        $this->avs_cvv2_result_admin_email = 'yes' === $this->get_option('avs_cvv2_result_admin_email', 'no');
         $this->fraud_management_filters = $this->get_option('fraud_management_filters', 'place_order_on_hold_for_further_review');
         $this->notifyurl = '';
         if ($this->enable_notifyurl == 'yes') {
@@ -116,7 +116,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 $this->enable_3dsecure = false;
             $this->centinel_url = $this->testmode == false ? $this->liveurl_3ds : $this->testurl_3ds;
         }
-        
+
         //fix ssl for image icon
         $this->icon = $this->get_option('card_icon', plugins_url('/assets/images/cards.png', plugin_basename(dirname(__FILE__))));
         if ( is_ssl() || 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ) {
@@ -164,12 +164,12 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         if ($this->enable_cardholder_first_last_name) {
             add_action('woocommerce_credit_card_form_start', array($this, 'angelleye_woocommerce_credit_card_form_start'), 10, 1);
         }
-        
+
         add_filter('woocommerce_credit_card_form_fields', array($this, 'angelleye_paypal_pro_credit_card_form_fields'), 10, 2);
         if( $this->avs_cvv2_result_admin_email ) {
             add_action( 'woocommerce_email_before_order_table', array( $this, 'angelleye_paypal_pro_email_instructions' ), 10, 3 );
         }
-       
+
         $this->customer_id;
         if (class_exists('WC_Gateway_Calculation_AngellEYE')) {
             $this->calculation_angelleye = new WC_Gateway_Calculation_AngellEYE();
@@ -204,7 +204,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 'description' => __('This controls the description which the user sees during checkout.', 'paypal-for-woocommerce'),
                 'default' => __('Pay with your credit card', 'paypal-for-woocommerce')
             ),
-           
+
             'invoice_id_prefix' => array(
                 'title' => __('Invoice ID Prefix', 'paypal-for-woocommerce'),
                 'type' => 'text',
@@ -417,18 +417,18 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         );
         $this->form_fields = apply_filters('angelleye_pc_form_fields', $this->form_fields);
     }
-    
-    
+
+
     public function admin_options() {
         echo '<h2>' . esc_html( $this->get_method_title() ) . '</h2>';
         echo wp_kses_post( wpautop( $this->get_method_description() ) );
         ?>
         <table class="form-table">
-            <?php 
+            <?php
             if(version_compare(WC_VERSION,'2.6','<')) {
-                AngellEYE_Utility::woo_compatibility_notice();    
+                AngellEYE_Utility::woo_compatibility_notice();
             } else {
-               $this->generate_settings_html(); 
+               $this->generate_settings_html();
             }
             ?>
         </table>
@@ -454,7 +454,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         </script>
         <?php
     }
-    
+
 
     /**
      * Check if this gateway is enabled and available in the user's country
@@ -519,7 +519,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         }
         do_action('payment_fields_saved_payment_methods', $this);
     }
-    
+
     public function save_payment_method_checkbox() {
         printf(
                 '<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
@@ -588,12 +588,12 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             $card_start_month = '';
             $card_start_year = '';
         }
-        
+
         $card_exp_month = (int) $card_exp_month;
         if ($card_exp_month < 10) {
             $card_exp_month = '0' . $card_exp_month;
         }
-        
+
         if (strlen($card_exp_year) == 2) {
             $card_exp_year += 2000;
         }
@@ -631,13 +631,13 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             }
 
             // Validate values
-            if (!ctype_digit($card->cvc)) {
+            if (!ctype_digit((string) $card->cvc)) {
                 throw new Exception(__('Card security code is invalid (only digits are allowed)', 'paypal-for-woocommerce'));
             }
 
             if (
-                    !ctype_digit($card->exp_month) ||
-                    !ctype_digit($card->exp_year) ||
+                    !ctype_digit((string) $card->exp_month) ||
+                    !ctype_digit((string) $card->exp_year) ||
                     $card->exp_month > 12 ||
                     $card->exp_month < 1 ||
                     $card->exp_year < date('y')
@@ -645,7 +645,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 throw new Exception(__('Card expiration date is invalid', 'paypal-for-woocommerce'));
             }
 
-            if (empty($card->number) || !ctype_digit($card->number)) {
+            if (empty($card->number) || !ctype_digit((string) $card->number)) {
                 throw new Exception(__('Card number is invalid', 'paypal-for-woocommerce'));
             }
 
@@ -702,7 +702,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             WC()->session->set('CardExpYear', $card->exp_year);
             $this->centinel_client->add('CardCode', $card->cvc);
             WC()->session->set('CardCode', $card->cvc);
-            
+
             $billing_first_name = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_first_name : $order->get_billing_first_name();
             $billing_last_name = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_last_name : $order->get_billing_last_name();
             $billing_address_1 = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_address_1 : $order->get_billing_address_1();
@@ -712,7 +712,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             $billing_country = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_country : $order->get_billing_country();
             $billing_state = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_state : $order->get_billing_state();
             $billing_phone = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_phone : $order->get_billing_phone();
-        
+
             $this->centinel_client->add('BillingFirstName', $billing_first_name);
             $this->centinel_client->add('BillingLastName', $billing_last_name);
             $this->centinel_client->add('BillingAddress1', $billing_address_1);
@@ -947,8 +947,8 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             $firstname = wc_clean($_POST['paypal_pro-card-cardholder-first']);
         } else {
             $firstname = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_first_name : $order->get_billing_first_name();
-        }       
-           
+        }
+
         if(!empty($_POST['paypal_pro-card-cardholder-last'])) {
             $lastname = wc_clean($_POST['paypal_pro-card-cardholder-last']);
         } else {
@@ -977,7 +977,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             'issuenumber' => ''                            // Issue number of Maestro or Solo card.  Two numeric digits max.
         );
 
-        
+
         $billing_address_1 = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_address_1 : $order->get_billing_address_1();
         $billing_address_2 = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_address_2 : $order->get_billing_address_2();
         $billing_city = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_city : $order->get_billing_city();
@@ -986,8 +986,8 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         $billing_state = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_state : $order->get_billing_state();
         $billing_email = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_email : $order->get_billing_email();
         $billing_phone = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_phone : $order->get_billing_phone();
-        
-        
+
+
         $PayerInfo = array(
             'email' => $billing_email,                                // Email address of payer.
             'firstname' => $firstname, // Required.  Payer's first name.
@@ -1262,7 +1262,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                     if ( $old_wc ) {
                         if ( ! get_post_meta( $order_id, '_order_stock_reduced', true ) ) {
                             $order->reduce_order_stock();
-                        } 
+                        }
                     } else {
                         wc_maybe_reduce_stock_levels( $order_id );
                     }
@@ -1278,7 +1278,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                     if ( $old_wc ) {
                         if ( ! get_post_meta( $order_id, '_order_stock_reduced', true ) ) {
                             $order->reduce_order_stock();
-                        } 
+                        }
                     } else {
                         wc_maybe_reduce_stock_levels( $order_id );
                     }
@@ -1288,7 +1288,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             } else {
                 $this->angelleye_update_status($order, $PayPalResult['TRANSACTIONID']);
             }
-            
+
             if ($this->payment_action == "Authorization") {
                 if ($old_wc) {
                     update_post_meta($order_id, '_first_transaction_id', $PayPalResult['TRANSACTIONID']);
@@ -1636,8 +1636,8 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             } else {
                 throw new Exception( __( 'Invalid or missing payment token fields.', 'paypal-for-woocommerce' ) );
             }
-            
-           
+
+
         } else {
             $redirect_url = wc_get_account_endpoint_url('payment-methods');
             $this->paypal_pro_error_handler($request_name = 'DoDirectPayment', $redirect_url, $result);
@@ -1663,7 +1663,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         }
         return $settings;
     }
-    
+
     public function angelleye_paypal_pro_email_instructions($order, $sent_to_admin, $plain_text = false) {
         $payment_method = version_compare( WC_VERSION, '3.0', '<' ) ? $order->payment_method : $order->get_payment_method();
         if ( $sent_to_admin && 'paypal_pro' === $payment_method ) {
@@ -1742,7 +1742,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         $billing_state = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_state : $order->get_billing_state();
         $billing_email = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_email : $order->get_billing_email();
         $billing_phone = version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_phone : $order->get_billing_phone();
-        
+
         $PayerInfo = array(
             'email' => $billing_email, // Email address of payer.
             'firstname' => $billing_first_name, // Required.  Payer's first name.
@@ -1757,10 +1757,10 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             'zip' => $billing_postcode, // Required.  Postal code of payer.
             'phonenum' => $billing_phone                        // Phone Number of payer.  20 char max.
         );
-        
+
         $shipping_first_name = version_compare( WC_VERSION, '3.0', '<' ) ? $order->shipping_first_name : $order->get_shipping_first_name();
         $shipping_last_name = version_compare( WC_VERSION, '3.0', '<' ) ? $order->shipping_last_name : $order->get_shipping_last_name();
-        
+
         $ShippingAddress = array(
             'shiptoname' => $shipping_first_name . ' ' . $shipping_last_name,                    // Required if shipping is included.  Person's name associated with this address.  32 char max.
             'shiptostreet' => version_compare( WC_VERSION, '3.0', '<' ) ? $order->shipping_address_1 : $order->get_shipping_address_1(),                    // Required if shipping is included.  First street address.  100 char max.
@@ -1771,7 +1771,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             'shiptocountry' => version_compare( WC_VERSION, '3.0', '<' ) ? $order->shipping_country : $order->get_shipping_country(),                    // Required if shipping is included.  Country code of shipping address.  2 char max.
             'shiptophonenum' => version_compare( WC_VERSION, '3.0', '<' ) ? $order->billing_phone : $order->get_billing_phone()                    // Phone number for shipping address.  20 char max.
         );
-        
+
         $customer_note_value = version_compare(WC_VERSION, '3.0', '<') ? wptexturize($order->customer_note) : wptexturize($order->get_customer_note());
         $customer_note = $customer_note_value ? substr(preg_replace("/[^A-Za-z0-9 ]/", "", $customer_note_value), 0, 256) : '';
         $PaymentDetails = array(
@@ -1898,7 +1898,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 if ( $old_wc ) {
                     if ( ! get_post_meta( $order_id, '_order_stock_reduced', true ) ) {
                         $order->reduce_order_stock();
-                    } 
+                    }
                 } else {
                     wc_maybe_reduce_stock_levels( $order_id );
                 }
@@ -1942,7 +1942,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             update_post_meta($order_id, '_payment_tokens_id', $payment_tokens_id);
         }
     }
-    
+
     public function free_signup_order_payment($order_id) {
         $order = new WC_Order($order_id);
         $this->log('Processing order #' . $order_id);
@@ -1958,9 +1958,9 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 'result' => 'success',
                 'redirect' => $this->get_return_url($order)
             );
-        } 
+        }
     }
-    
+
     public function is_subscription($order_id) {
         return ( function_exists('wcs_order_contains_subscription') && ( wcs_order_contains_subscription($order_id) || wcs_is_subscription($order_id) || wcs_order_contains_renewal($order_id) ) );
     }
@@ -1978,7 +1978,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                 if ( $old_wc ) {
                     if ( ! get_post_meta( $order_id, '_order_stock_reduced', true ) ) {
                         $order->reduce_order_stock();
-                    } 
+                    }
                 } else {
                     wc_maybe_reduce_stock_levels( $order_id );
                 }
@@ -1986,7 +1986,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             }
         }
     }
-    
+
     public function angelleye_reload_gateway_credentials_for_woo_subscription_renewal_order($order) {
         if( $this->testmode == false ) {
             $order_id = version_compare(WC_VERSION, '3.0', '<') ? $order->id : $order->get_id();
@@ -2002,12 +2002,12 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                             $this->api_password = $this->get_option('sandbox_api_password');
                             $this->api_signature = $this->get_option('sandbox_api_signature');
                         }
-                    }        
+                    }
                 }
             }
         }
     }
-    
+
     public function angelleye_get_transaction_details($order_id, $transaction_id) {
         $this->angelleye_load_paypal_pro_class($this->gateway, $this, $order_id);
         $GTDFields = array(
@@ -2018,7 +2018,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         $this->log(print_r($get_transactionDetails_result, true));
         $this->update_payment_status_by_paypal_responce($order_id, $get_transactionDetails_result, $transaction_id);
     }
-    
+
     public function update_payment_status_by_paypal_responce($orderid, $result, $transaction_id) {
         try {
             $order = wc_get_order($orderid);
@@ -2104,7 +2104,7 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
                         if ( $old_wc ) {
                             if ( ! get_post_meta( $orderid, '_order_stock_reduced', true ) ) {
                                 $order->reduce_order_stock();
-                            } 
+                            }
                         } else {
                             wc_maybe_reduce_stock_levels( $orderid );
                         }
@@ -2121,10 +2121,10 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
             endswitch;
             return;
         } catch (Exception $ex) {
-            
+
         }
     }
-    
+
     public function angelleye_load_paypal_pro_class($gateway, $current, $order_id = null) {
         do_action('angelleye_paypal_for_woocommerce_multi_account_api_paypal_pro', $gateway, $current, $order_id);
         if (!class_exists('Angelleye_PayPal_WC')) {
@@ -2139,6 +2139,6 @@ class WC_Gateway_PayPal_Pro_AngellEYE extends WC_Payment_Gateway_CC {
         );
         $this->PayPal = new Angelleye_PayPal_WC($PayPalConfig);
     }
-    
-    
+
+
 }

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -122,10 +122,10 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway_CC {
         $this->fraud_warning_codes = array('126', '127');
         do_action( 'angelleye_paypal_for_woocommerce_multi_account_api_' . $this->id, $this, null, null );
         add_action('admin_notices', array($this, 'angelleye_paypal_pro_payflow_reference_transaction_notice'));
-        
+
     }
 
-    public function add_log($message, $level = 'info') {        
+    public function add_log($message, $level = 'info') {
         if ($this->debug) {
             if (version_compare(WC_VERSION, '3.0', '<')) {
                 if (empty($this->log)) {
@@ -135,11 +135,11 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway_CC {
             } else {
                 if (empty($this->log)) {
                     $this->log = wc_get_logger();
-                }     
+                }
                 $this->log->log($level,sprintf(__('PayPal for WooCommerce Version: %s', 'paypal-for-woocommerce'), VERSION_PFW),array('source' => 'paypal_pro_payflow'));
                 $this->log->log($level,sprintf(__('WooCommerce Version: %s', 'paypal-for-woocommerce'), WC_VERSION),array('source' => 'paypal_pro_payflow'));
                 $this->log->log($level,'Test Mode: ' . $this->testmode,array('source' => 'paypal_pro_payflow'));
-                $this->log->log($level, $message, array('source' => 'paypal_pro_payflow'));              
+                $this->log->log($level, $message, array('source' => 'paypal_pro_payflow'));
             }
         }
     }
@@ -169,7 +169,7 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway_CC {
                 'description' => __('This controls the description which the user sees during checkout.', 'paypal-for-woocommerce'),
                 'default' => __('Pay with your credit card.', 'paypal-for-woocommerce')
             ),
-           
+
             'invoice_id_prefix' => array(
                 'title' => __('Invoice ID Prefix', 'paypal-for-woocommerce'),
                 'type' => 'text',
@@ -181,7 +181,7 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway_CC {
                 'default' => plugins_url('/assets/images/payflow-cards.png', plugin_basename(dirname(__FILE__))),
                 'class' => 'button_upload'
             ),
-            
+
             'error_email_notify' => array(
                 'title' => __('Error Email Notifications', 'paypal-for-woocommerce'),
                 'type' => 'checkbox',
@@ -222,7 +222,7 @@ class WC_Gateway_PayPal_Pro_PayFlow_AngellEYE extends WC_Payment_Gateway_CC {
                 'custom_attributes' => array( 'autocomplete' => 'off'),
                 'default' => 'angelleye'
             ),
-            
+
             'sandbox_paypal_user' => array(
                 'title' => __('User (optional)', 'paypal-for-woocommerce'),
                 'type' => 'text',
@@ -411,15 +411,15 @@ of the user authorized to process transactions. Otherwise, leave this field blan
         );
         $this->form_fields = apply_filters('angelleye_fc_form_fields', $this->form_fields);
     }
-    
-    
-    
+
+
+
     public function admin_options() {
         echo '<h2>' . esc_html( $this->get_method_title() ) . '</h2>';
         echo wp_kses_post( wpautop( $this->get_method_description() ) );
         ?>
         <table class="form-table">
-            <?php 
+            <?php
              if(!get_user_meta(get_current_user_id(), 'payflow_sb_autopopulate_credentials')){
                echo '<div class="notice notice-info"><p>'.sprintf(__("<h3>Default PayFlow Sandbox Credentials</h3>
                 <p>These values have been auto-filled into the sandbox credential fields so that you can quickly run test orders. If you have your own PayPal Manager test account you can update the values accordingly.</p>
@@ -433,9 +433,9 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 esc_url(add_query_arg("payflow_sb_autopopulate_credentials", 0)), __("Hide this notice.", 'paypal-for-woocommerce')) . '</p></div>';
             }
             if(version_compare(WC_VERSION,'2.6','<')) {
-                AngellEYE_Utility::woo_compatibility_notice();    
+                AngellEYE_Utility::woo_compatibility_notice();
             } else {
-               $this->generate_settings_html(); 
+               $this->generate_settings_html();
             }
             ?>
         </table>
@@ -553,7 +553,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
             if( $this->payment_action == 'Authorization' && $this->payment_action_authorization == 'Card Verification' ) {
                 $order_amt = '0.00';
             }
-                    
+
             $PayPalRequestData = array(
                 'tender' => 'C', // Required.  The method of payment.  Values are: A = ACH, C = Credit Card, D = Pinless Debit, K = Telecheck, P = PayPal
                 'trxtype' => ($this->payment_action == 'Authorization' || $order->get_total() == 0 ) ? 'A' : 'S', // Required.  Indicates the type of transaction to perform.  Values are:  A = Authorization, B = Balance Inquiry, C = Credit, D = Delayed Capture, F = Voice Authorization, I = Inquiry, L = Data Upload, N = Duplicate Transaction, S = Sale, V = Void
@@ -615,11 +615,11 @@ of the user authorized to process transactions. Otherwise, leave this field blan
             }
 
             $PaymentData = $this->calculation_angelleye->order_calculation($order_id);
-            
+
             if( !empty($PaymentData['discount_amount']) && $PaymentData['discount_amount'] > 0 ) {
                 $PayPalRequestData['discount'] = $PaymentData['discount_amount'];
             }
-            
+
             $OrderItems = array();
             if ($this->send_items) {
                 $item_loop = 0;
@@ -668,7 +668,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                     $log['cvv2'] = '****';
                 }
             }
-            
+
             $this->add_log('PayFlow Request: ' . print_r($log, true));
             $PayPalResult = $this->PayPal->ProcessTransaction(apply_filters('angelleye_woocommerce_paypal_pro_payflow_process_transaction_request_args', $PayPalRequestData));
             /**
@@ -883,7 +883,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
         }
         do_action('payment_fields_saved_payment_methods', $this);
     }
-    
+
     public function save_payment_method_checkbox() {
         printf(
                 '<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
@@ -906,7 +906,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
             $timestamp = mktime(0, 0, 0, $i, 1);
             $months[date('n', $timestamp)] = date_i18n(_x('F', 'Month Names', 'paypal-for-woocommerce'), $timestamp);
         endfor;
-        
+
         foreach ($months as $num => $name) {
             if( $this->credit_card_month_field == 'numbers' ) {
                 $month_value = ($num < 10) ? '0' . $num : $num;
@@ -971,7 +971,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
         /**
          * Check if the PayPal_PayFlow class has already been established.
          */
-        
+
 
         /**
          * Create PayPal_PayFlow object.
@@ -1045,21 +1045,28 @@ of the user authorized to process transactions. Otherwise, leave this field blan
 
         // Check card security code
 
-        if (!ctype_digit($card_cvc)) {
+        if (!ctype_digit((string) $card_cvc)) {
             wc_add_notice(__('Card security code is invalid (only digits are allowed)', 'paypal-for-woocommerce'), "error");
             return false;
         }
 
         // Check card expiration data
 
-        if (!ctype_digit($card_exp_month) || !ctype_digit($card_exp_year) || $card_exp_month > 12 || $card_exp_month < 1 || $card_exp_year < date('y') || $card_exp_year > date('y') + 20) {
+        if (
+                !ctype_digit((string) $card_exp_month) ||
+                !ctype_digit((string) $card_exp_year) ||
+                $card_exp_month > 12 ||
+                $card_exp_month < 1 ||
+                $card_exp_year < date('y') ||
+                $card_exp_year > date('y') + 20
+        ) {
             wc_add_notice(__('Card expiration date is invalid', 'paypal-for-woocommerce'), "error");
             return false;
         }
 
         // Check card number
 
-        if (empty($card_number) || !ctype_digit($card_number)) {
+        if (empty($card_number) || !ctype_digit((string) $card_number)) {
             wc_add_notice(__('Card number is invalid', 'paypal-for-woocommerce'), "error");
             return false;
         }
@@ -1124,7 +1131,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                     throw new Exception(__('Your processor is unable to process the Card Type in the currency requested. Please try another card type', 'paypal-for-woocommerce'));
                 }
             }
-             
+
             if (strlen($card_exp_year) == 4) {
                 $card_exp_year = $card_exp_year - 2000;
             }
@@ -1141,7 +1148,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                         'start_month' => '',
                         'start_year' => ''
             );
-        
+
     }
 
     public function add_payment_method() {
@@ -1603,14 +1610,14 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 }
                 echo '</ul></section>';
             }
-            
+
         }
     }
 
     public function is_subscription($order_id) {
         return ( function_exists('wcs_order_contains_subscription') && ( wcs_order_contains_subscription($order_id) || wcs_is_subscription($order_id) || wcs_order_contains_renewal($order_id) ) );
     }
-    
+
     public function angelleye_paypal_pro_payflow_reference_transaction_notice() {
         if(class_exists('AngellEYE_Utility')) {
             if (AngellEYE_Utility::is_display_angelleye_paypal_pro_payflow_reference_transaction_notice($this) == true) {
@@ -1618,7 +1625,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
             }
         }
     }
-    
+
     public function angelleye_load_paypal_payflow_class($gateway, $current, $order_id = null) {
         do_action('angelleye_paypal_for_woocommerce_multi_account_api_paypal_payflow', $gateway, $current, $order_id);
         $this->credentials = array(
@@ -1638,9 +1645,9 @@ of the user authorized to process transactions. Otherwise, leave this field blan
             }
             $this->PayPal = new Angelleye_PayPal_PayFlow($this->credentials);
         } catch (Exception $ex) {
-            
+
         }
     }
-    
+
 
 }


### PR DESCRIPTION
In multiple classes, card expiration months/years are juggled between strings and ints. This causes a problem because the validation is done with `ctype_digit()`, which _requires_ a string. An int will cause it to return `false`, even though the int arg is all digits (see [Example #2](http://php.net/ctype_digit#example-6300) and [both Notes](http://php.net/ctype_digit#refsect1-function.ctype-digit-notes) on [http://php.net/ctype_digit](http://php.net/ctype_digit))

For example, in the file `/classes/wc-gateway-paypal-pro-angelleye.php` on lines [592-595](https://github.com/angelleye/paypal-woocommerce/blob/4dc76c173785f6d2e8a61df502e8a1e8d3d9ed0e/classes/wc-gateway-paypal-pro-angelleye.php#L592) is this code:

```php
$card_exp_month = (int) $card_exp_month;
if ($card_exp_month < 10) {
    $card_exp_month = '0' . $card_exp_month;
}
```

If the card's expiration month is January through September (1-9), `$card_exp_month` is converted to a string by prepending `0`. However, if the expiration month is October through December (10-12), `$card_exp_month` remains an int. This ends up breaking the card validation, because the `validate_fields()` function, lines [638-646](https://github.com/angelleye/paypal-woocommerce/blob/4dc76c173785f6d2e8a61df502e8a1e8d3d9ed0e/classes/wc-gateway-paypal-pro-angelleye.php#L638) has this conditional:

```php
if (
        !ctype_digit($card->exp_month) ||
        !ctype_digit($card->exp_year) ||
        $card->exp_month > 12 ||
        $card->exp_month < 1 ||
        $card->exp_year < date('y')
) {
    throw new Exception(__('Card expiration date is invalid', 'paypal-for-woocommerce'));
}
```

_(this conditional is present in multiple classes)_

Since `ctype_digit()` returns `false` if you provide an int, if the expiration date is October through December (10-12) and `$card->exp_month` remains an int, the conditional is truthy and the "Card expiration date is invalid" exception is thrown.

This is easily tested by using an expiration month of October, November, or December.

This PR changes all `ctype_digit()` calls to forcibly type cast the parameter to a string, to ensure that regardless of how the variable has been set/changed, it is properly checked.