### PR TITLE
check for token match on ppe return, fix fatal error frontend

### DIFF
--- a/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-helper-angelleye.php
+++ b/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-helper-angelleye.php
@@ -576,6 +576,10 @@ class Angelleye_PayPal_Express_Checkout_Helper {
     }
 
     public function ec_enqueue_scripts_product_page($is_mini_cart = false) {
+        // @note WC()->session will not be set in admin and trigger a fatal error (not a catchable exception) - Skylar L
+        if (is_admin()) { 
+            return;
+        }
         try {
             $paypal_express_checkout = WC()->session->get('paypal_express_checkout');
             if (is_order_received_page()) {


### PR DESCRIPTION
Have had issues with cart / token mismatches, this checks for that. Also fixes fatal error in admin when the frontend scripts are enqueued.