### PR TITLE
Correct year format as per cardinal commerce docs

### DIFF
--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -702,7 +702,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 WC()->session->set('CardExpMonth', $card->exp_month);
                 $card_exp_year = DateTime::createFromFormat('y', $card->exp_year);
                 $card_exp_year_full = $card_exp_year->format('Y');
-                $this->centinel_client->add('CardExpYear',$card_exp_year_full);
+                $this->centinel_client->add('CardExpYear', $card_exp_year_full);
                 WC()->session->set('CardExpYear', $card->exp_year);
                 $this->centinel_client->add('CardCode', $card->cvc);
                 WC()->session->set('CardCode', $card->cvc);

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -700,7 +700,8 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 WC()->session->set('CardNumber', $card->number);
                 $this->centinel_client->add('CardExpMonth', $card->exp_month);
                 WC()->session->set('CardExpMonth', $card->exp_month);
-                $this->centinel_client->add('CardExpYear', $card->exp_year);
+                $card_exp_year = $dt->format('Y');
+                $this->centinel_client->add('CardExpYear',$card_exp_year);
                 WC()->session->set('CardExpYear', $card->exp_year);
                 $this->centinel_client->add('CardCode', $card->cvc);
                 WC()->session->set('CardCode', $card->cvc);

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -700,7 +700,7 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 WC()->session->set('CardNumber', $card->number);
                 $this->centinel_client->add('CardExpMonth', $card->exp_month);
                 WC()->session->set('CardExpMonth', $card->exp_month);
-		$card_exp_year = DateTime::createFromFormat('y', $card->exp_year);
+                $card_exp_year = DateTime::createFromFormat('y', $card->exp_year);
                 $card_exp_year_full = $card_exp_year->format('Y');
                 $this->centinel_client->add('CardExpYear',$card_exp_year_full);
                 WC()->session->set('CardExpYear', $card->exp_year);

--- a/classes/wc-gateway-paypal-pro-payflow-angelleye.php
+++ b/classes/wc-gateway-paypal-pro-payflow-angelleye.php
@@ -700,8 +700,9 @@ of the user authorized to process transactions. Otherwise, leave this field blan
                 WC()->session->set('CardNumber', $card->number);
                 $this->centinel_client->add('CardExpMonth', $card->exp_month);
                 WC()->session->set('CardExpMonth', $card->exp_month);
-                $card_exp_year = $dt->format('Y');
-                $this->centinel_client->add('CardExpYear',$card_exp_year);
+		$card_exp_year = DateTime::createFromFormat('y', $card->exp_year);
+                $card_exp_year_full = $card_exp_year->format('Y');
+                $this->centinel_client->add('CardExpYear',$card_exp_year_full);
                 WC()->session->set('CardExpYear', $card->exp_year);
                 $this->centinel_client->add('CardCode', $card->cvc);
                 WC()->session->set('CardCode', $card->cvc);


### PR DESCRIPTION
As per Cardinal Commerce documentation, CardExpYear should be sent through in full 4-digit format rather than shortened 2 digit. Payflow requires 2 digit, so it should continue to be stored as-is for transactions.

Was receiving this API response from Cardinal Centinel before this patch: Error Validating Credit Card Expiration Information Passed (YYMM) [null]. Have confirmed the issue with a contact from Cardinal Commerce.

See CardExpYear here for docs https://cardinaldocs.atlassian.net/wiki/spaces/CCen/pages/905478187/Lookup+Request+Response