### PR TITLE
Get order currency on Paypal Transaction History

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -1144,7 +1144,7 @@ class AngellEYE_Utility {
                     </tr>
                     <tr>
                         <td><?php echo __('Total Capture:', 'paypal-for-woocommerce'); ?></td>
-                        <td><?php echo get_woocommerce_currency_symbol() . '' . $this->total_DoCapture ?></td>
+                        <td><?php echo get_woocommerce_currency_symbol( $order->get_currency() ) . '' . $this->total_DoCapture ?></td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
Paypal transaction history is showing the wrong order currency because it's getting it from the base shop currency.
I think we just have to pass the order currency to `get_woocommerce_currency_symbol()` to show it correctly

![angelleye](https://user-images.githubusercontent.com/8193404/76360661-32b19180-62fc-11ea-94a0-cbf555649e6d.png)
