### PR TITLE
Correct spelling of length property

### DIFF
--- a/classes/wc-gateway-braintree-angelleye.php
+++ b/classes/wc-gateway-braintree-angelleye.php
@@ -976,7 +976,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
                                 if ( $('.is_submit').length > 0) {
                                     return true;
                                 }
-                                if( $('.braintree-token').lenght > 0) {
+                                if( $('.braintree-token').length > 0) {
                                     return true;
                                 }
                                 event.preventDefault();


### PR DESCRIPTION
The length property for braintree-token on the Woocommerce checkout form was misspelled as lenght