### PR TITLE
Change subscription payment method to ACH

### DIFF
--- a/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
+++ b/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
@@ -70,6 +70,8 @@ class WC_Gateway_Braintree_Subscriptions_AngellEYE extends WC_Gateway_Braintree_
             $subscriptions = wcs_get_subscriptions_for_order($order_id);
         } elseif (function_exists('wcs_order_contains_renewal') && wcs_order_contains_renewal($order_id)) {
             $subscriptions = wcs_get_subscriptions_for_renewal_order($order_id);
+        } elseif (function_exists('wcs_is_subscription') && wcs_is_subscription($order_id)) {
+            $subscriptions = array(0=>$order);
         } else {
             $subscriptions = array();
         }

--- a/classes/wc-gateway-braintree-angelleye.php
+++ b/classes/wc-gateway-braintree-angelleye.php
@@ -1086,7 +1086,8 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         $order = wc_get_order($order_id);
         if( $this->enable_braintree_ach && isset($_POST['braintree_ach_token'] )) {
             $braintree_customer_id = $this->angelleye_braintree_ach_create_customer_id($order);
-            $payment_method_token = $this->braintree_ach_create_payment_method($braintree_customer_id);
+            $result = $this->braintree_ach_create_payment_method($braintree_customer_id);
+            $payment_method_token = $result->paymentMethod->token;
             if($payment_method_token) {
                 $success = $this->angelleye_ach_process_payment($order, $payment_method_token);
             }


### PR DESCRIPTION
A customer signs up for a subscription via Woocommerce Subscriptions and pays with their bank account(ACH). They later decide to use another bank account for this subscription. They go to the payment method update page, enter in the new account info and submit. The notice on the page says that payment info has been updated.

However, the next time the subscription is charged, the payment does not appear on the updated account. It appears on the old account.

Once the customer submits the update, there appear to be two places where credit card is assumed as the method of payment. Both are in `classes/wc-gateway-braintree-angelleye.php`:
* `add_payment_method` function: when creating the payment method in braintree, the `braintree_create_payment_method` function does not perform a network check on the bank account. So even if the correct token was saved, the next transaction would fail b/c the bank account is not verified.
* `braintree_save_payment_method` function: it attempts to find the token in the WP database. If that fails, it then tries to create a credit card token. When it attempts to validate that token, the process errors out b/c there is no credit card data(since the payment method is ACH).