### PR TITLE
Add payment method type to subscription

### DIFF
--- a/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
+++ b/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
@@ -70,6 +70,8 @@ class WC_Gateway_Braintree_Subscriptions_AngellEYE extends WC_Gateway_Braintree_
             $subscriptions = wcs_get_subscriptions_for_order($order_id);
         } elseif (function_exists('wcs_order_contains_renewal') && wcs_order_contains_renewal($order_id)) {
             $subscriptions = wcs_get_subscriptions_for_renewal_order($order_id);
+        } elseif (function_exists('wcs_is_subscription') && wcs_is_subscription($order_id)) {
+            $subscriptions = array(0=>$order);
         } else {
             $subscriptions = array();
         }

--- a/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
+++ b/classes/subscriptions/wc-gateway-braintree-subscriptions-angelleye.php
@@ -48,6 +48,10 @@ class WC_Gateway_Braintree_Subscriptions_AngellEYE extends WC_Gateway_Braintree_
                 '_payment_tokens_id' => array(
                     'value' => get_post_meta($subscription_id, '_payment_tokens_id', true),
                     'label' => 'Payment Tokens ID',
+                ),
+                '_payment_method_type' => array(
+                    'value' => get_post_meta($subscription_id, '_payment_method_type', true),
+                    'label' => 'Payment Method Type',
                 )
             )
         );
@@ -70,8 +74,6 @@ class WC_Gateway_Braintree_Subscriptions_AngellEYE extends WC_Gateway_Braintree_
             $subscriptions = wcs_get_subscriptions_for_order($order_id);
         } elseif (function_exists('wcs_order_contains_renewal') && wcs_order_contains_renewal($order_id)) {
             $subscriptions = wcs_get_subscriptions_for_renewal_order($order_id);
-        } elseif (function_exists('wcs_is_subscription') && wcs_is_subscription($order_id)) {
-            $subscriptions = array(0=>$order);
         } else {
             $subscriptions = array();
         }

--- a/classes/wc-gateway-braintree-angelleye.php
+++ b/classes/wc-gateway-braintree-angelleye.php
@@ -1086,7 +1086,8 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         $order = wc_get_order($order_id);
         if( $this->enable_braintree_ach && isset($_POST['braintree_ach_token'] )) {
             $braintree_customer_id = $this->angelleye_braintree_ach_create_customer_id($order);
-            $payment_method_token = $this->braintree_ach_create_payment_method($braintree_customer_id);
+            $result = $this->braintree_ach_create_payment_method($braintree_customer_id);
+            $payment_method_token = $result->paymentMethod->token;
             if($payment_method_token) {
                 $success = $this->angelleye_ach_process_payment($order, $payment_method_token);
             }

--- a/classes/wc-gateway-braintree-angelleye.php
+++ b/classes/wc-gateway-braintree-angelleye.php
@@ -1086,8 +1086,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         $order = wc_get_order($order_id);
         if( $this->enable_braintree_ach && isset($_POST['braintree_ach_token'] )) {
             $braintree_customer_id = $this->angelleye_braintree_ach_create_customer_id($order);
-            $result = $this->braintree_ach_create_payment_method($braintree_customer_id);
-            $payment_method_token = $result->paymentMethod->token;
+            $payment_method_token = $this->braintree_ach_create_payment_method($braintree_customer_id);
             if($payment_method_token) {
                 $success = $this->angelleye_ach_process_payment($order, $payment_method_token);
             }
@@ -1248,7 +1247,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         try {
             $result = $this->braintree_gateway->paymentMethod()->create($payment_method_request);
             if(isset($result->paymentMethod->verified) && ($result->paymentMethod->verified)) {
-                return $result;
+                return $result->paymentMethod->token;
             } else {
                 if( isset($result->paymentMethod->verifications[0]->processorResponseText) && !empty($result->paymentMethod->verifications[0]->processorResponseText)) {
                      wc_add_notice($result->paymentMethod->verifications[0]->processorResponseText, 'error');
@@ -2050,11 +2049,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         $customer_id = get_current_user_id();
         $braintree_customer_id = get_user_meta($customer_id, 'braintree_customer_id', true);
         if (!empty($braintree_customer_id)) {
-            if ( $this->enable_braintree_ach && isset($_POST['braintree_ach_token'] )) {
-                $result = $this->braintree_ach_create_payment_method($braintree_customer_id);
-            } else {
-                $result = $this->braintree_create_payment_method($braintree_customer_id, $zero_amount_payment);
-            }
+            $result = $this->braintree_create_payment_method($braintree_customer_id, $zero_amount_payment);
             if ($result->success == true) {
                 $return = $this->braintree_save_payment_method($customer_id, $result, $zero_amount_payment);
                 return $return;
@@ -2068,11 +2063,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         } else {
             $braintree_customer_id = $this->braintree_create_customer($customer_id);
             if (!empty($braintree_customer_id)) {
-                if( $this->enable_braintree_ach && isset($_POST['braintree_ach_token'] )) {
-                    $result = $this->braintree_ach_create_payment_method($braintree_customer_id);
-                } else {
-                    $result = $this->braintree_create_payment_method($braintree_customer_id, $zero_amount_payment);
-                }
+                $result = $this->braintree_create_payment_method($braintree_customer_id, $zero_amount_payment);
                 if ($result->success == true) {
                     $return = $this->braintree_save_payment_method($customer_id, $result, $zero_amount_payment);
                     return $return;
@@ -2171,68 +2162,61 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         }
         update_user_meta($customer_id, 'braintree_customer_id', $braintree_method->customerId);
         $payment_method_token = $braintree_method->token;
-        if ( is_a($braintree_method, 'Braintree\CreditCard') ) {
-            $wc_existing_token = $this->get_token_by_token($payment_method_token);
-            if ($wc_existing_token == null) {
-                $token = new WC_Payment_Token_CC();
-                if (!empty($braintree_method->cardType) && !empty($braintree_method->last4)) {
-                    $token->set_token($payment_method_token);
-                    $token->set_gateway_id($this->id);
-                    $token->set_card_type($braintree_method->cardType);
-                    $token->set_last4($braintree_method->last4);
-                    $token->set_expiry_month($braintree_method->expirationMonth);
-                    $token->set_expiry_year($braintree_method->expirationYear);
-                    $token->set_user_id($customer_id);
-                } elseif (!empty($braintree_method->billingAgreementId)) {    
-                $customer_id = get_current_user_id();
-                    $token->set_token($payment_method_token);
-                    $token->set_gateway_id($this->id);
-                    $token->set_card_type('PayPal Billing Agreement');
-                    $token->set_last4(substr($braintree_method->billingAgreementId, -4));
-                    $token->set_expiry_month(date('m'));
-                    $token->set_expiry_year(date('Y', strtotime('+20 year')));
-                    $token->set_user_id($customer_id); 
-                }
-                if ($token->validate()) {
-                    $save_result = $token->save();
-                    if ($save_result) {
-                        return array(
-                            'result' => 'success',
-                            '_payment_tokens_id' => $payment_method_token,
-                            'redirect' => wc_get_account_endpoint_url('payment-methods')
-                        );
-                    } else {
-                        if ($zero_amount_payment == false) {
-                            wp_redirect(wc_get_account_endpoint_url('payment-methods'));
-                            exit;
-                        } else {
-                            return array(
-                                'result' => 'success',
-                                '_payment_tokens_id' => $payment_method_token,
-                                'redirect' => wc_get_account_endpoint_url('payment-methods')
-                            );
-                        }
-                    }
-                } else {
-                    throw new Exception(__('Invalid or missing payment token fields.', 'paypal-for-woocommerce'));
-                }
-            } else {
-                if ($zero_amount_payment == false) {
-                    wp_redirect(wc_get_account_endpoint_url('payment-methods'));
-                    exit;
-                } else {
+        $wc_existing_token = $this->get_token_by_token($payment_method_token);
+        if ($wc_existing_token == null) {
+            $token = new WC_Payment_Token_CC();
+            if (!empty($braintree_method->cardType) && !empty($braintree_method->last4)) {
+                $token->set_token($payment_method_token);
+                $token->set_gateway_id($this->id);
+                $token->set_card_type($braintree_method->cardType);
+                $token->set_last4($braintree_method->last4);
+                $token->set_expiry_month($braintree_method->expirationMonth);
+                $token->set_expiry_year($braintree_method->expirationYear);
+                $token->set_user_id($customer_id);
+            } elseif (!empty($braintree_method->billingAgreementId)) {    
+               $customer_id = get_current_user_id();
+                $token->set_token($payment_method_token);
+                $token->set_gateway_id($this->id);
+                $token->set_card_type('PayPal Billing Agreement');
+                $token->set_last4(substr($braintree_method->billingAgreementId, -4));
+                $token->set_expiry_month(date('m'));
+                $token->set_expiry_year(date('Y', strtotime('+20 year')));
+                $token->set_user_id($customer_id); 
+            }
+            if ($token->validate()) {
+                $save_result = $token->save();
+                if ($save_result) {
                     return array(
                         'result' => 'success',
                         '_payment_tokens_id' => $payment_method_token,
                         'redirect' => wc_get_account_endpoint_url('payment-methods')
                     );
+                } else {
+                    if ($zero_amount_payment == false) {
+                        wp_redirect(wc_get_account_endpoint_url('payment-methods'));
+                        exit;
+                    } else {
+                        return array(
+                            'result' => 'success',
+                            '_payment_tokens_id' => $payment_method_token,
+                            'redirect' => wc_get_account_endpoint_url('payment-methods')
+                        );
+                    }
                 }
+            } else {
+                throw new Exception(__('Invalid or missing payment token fields.', 'paypal-for-woocommerce'));
             }
         } else {
-            return array(
-                'result' => 'success',
-                '_payment_tokens_id' => $payment_method_token
-            );            
+            if ($zero_amount_payment == false) {
+                wp_redirect(wc_get_account_endpoint_url('payment-methods'));
+                exit;
+            } else {
+                return array(
+                    'result' => 'success',
+                    '_payment_tokens_id' => $payment_method_token,
+                    'redirect' => wc_get_account_endpoint_url('payment-methods')
+                );
+            }
         }
     }
 


### PR DESCRIPTION
This adds the payment method type to the payload of post meta returned when the `woocommerce_subscription_payment_meta` hook fires. This is useful for making decisions based on subscription payment method type.