### PR TITLE
Allowing filter of paypal flow

### DIFF
--- a/classes/wc-gateway-braintree-angelleye.php
+++ b/classes/wc-gateway-braintree-angelleye.php
@@ -585,6 +585,8 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
         } else {
             $is_registration_required = WC()->checkout()->is_registration_required();
         }
+
+        $paypal_flow = apply_filters('angelleye_braintree_modify_paypal_flow', 'checkout') ?: 'checkout';
         ?>
         <script type="text/javascript">
             var js_variable = <?php echo json_encode($js_variable); ?>;
@@ -655,7 +657,7 @@ class WC_Gateway_Braintree_AngellEYE extends WC_Payment_Gateway_CC {
                             }
                         });
                         var paypal_option = {
-                            flow: 'checkout',
+                            flow: '<?php echo $paypal_flow; ?>',
                             amount: '<?php echo $order_total; ?>',
                             currency: '<?php echo get_woocommerce_currency(); ?>'
                           }


### PR DESCRIPTION
We were previously using the 'angelleye_braintree_store_in_vault_on_success' filter set to always return true, to force vaulting & tokenization of all transactions. This was necessary for us to link all of our customer orders and payment info into our internal POS System. 

We found after the recent updates, that with the [flow](https://github.com/angelleye/paypal-woocommerce/blob/a186692925fbf14918c26f24a398ac624376e9f2/classes/wc-gateway-braintree-angelleye.php#L658) hard-coded to 'checkout' rather than 'vault' [as it was](https://github.com/angelleye/paypal-woocommerce/blob/a165893019569446acdf67adb5b45bba50d81ff7/classes/wc-gateway-braintree-angelleye.php#L665) in the release we were upgrading from (v2.5.4) no PayPal transactions were storing payment tokens in the braintree vault. 
It appears there was a change in [PF-494](https://github.com/angelleye/paypal-woocommerce/commit/92cf5664c2eb7a3e8cb68f71383f988cf3150b26#diff-2f3405e3a5780cb3971b4275c3aedf45c9685757628ec18ca07922845552c572L656) which would have allowed us to change this via a setting, but it seems it [didn't make it](https://github.com/angelleye/paypal-woocommerce/pull/1575/commits/dd2f3e798a764ea565bc6fbfcd81facdb370c3ed) into a final release? 

Adding a apply_filter to set this variable dynamically, and setting it to 'vault' via a filter in our theme or plugin fixes this issue for us, and lets us once again store tokenized PayPal transactions in the Braintree vault via our previously mentioned method. 

I think it would be awesome if we could either get that official fix from PF-494 back into the release version (unless there was a good reason not to do so), or get the ability to filter this ourselves if you guys didn't want that in the options page as an easily changeable setting. 

Appreciate you looking into it, thanks!