### PR TITLE
Fix early textdomain loading notice

### DIFF
--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -47,6 +47,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
 
         public function __construct() {
             $this->define_constants();
+            $this->load_plugin_textdomain();
             $this->minified_version = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '' : '.min';
             $this->pp_settings = get_option('woocommerce_paypal_express_settings', array());
             $this->initialize_actions();


### PR DESCRIPTION
## Summary
- load plugin textdomain earlier in the constructor

## Testing
- `php -l paypal-for-woocommerce.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd5879dc832ebd1b151ef5b8e916