### PR TITLE
PFW-1950 - Fix: Ensure payment gateways load on correct hook for consistent detection

### DIFF
--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -102,7 +102,6 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             add_action('init', array($this, 'load_plugin_textdomain'));
             add_action('wp_loaded', array($this, 'load_cartflow_pro_plugin'), 20);
             add_action('add_meta_boxes', array($this, 'add_meta_boxes'), 32);
-            add_action('init', array($this, 'init'), 103);
             add_action('plugins_loaded', array($this, 'load_funnelkit_pro_plugin_compatible_gateways'), 5);
             add_action('admin_notices', array($this, 'admin_notices'));
             add_action('admin_init', array($this, 'set_ignore_tag'));
@@ -127,6 +126,12 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             add_action('wp', array(__CLASS__, 'angelleye_delete_payment_method_action'), 10);
             add_action('init', array($this, 'angelleye_register_post_status'), 99);
             add_action('current_screen', array($this, 'angelleye_redirect_to_onboard'), 9);
+            add_action('plugins_loaded', [$this, 'include_gateway_in_list'], 1000);
+        }
+
+        public function include_gateway_in_list() {
+            $this->init();
+            add_filter('woocommerce_payment_gateways', array($this, 'angelleye_add_paypal_pro_gateway'), 1000);
         }
 
         private function include_files_and_classes() {
@@ -315,10 +320,8 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             AngellEYE_PayPal_PPCP_Pay_Later::instance();
             AngellEYE_PayPal_PPCP_Admin_Action::instance();
             AngellEYE_PayPal_PPCP_Front_Action::instance();
-            add_filter('woocommerce_payment_gateways', array($this, 'angelleye_add_paypal_pro_gateway'), 1000);
             AngellEye_PayPal_PPCP_Apple_Domain_Validation::instance();
             AngellEye_Session_Manager::instance();
-            add_filter('woocommerce_payment_gateways', array($this, 'angelleye_add_paypal_pro_gateway'), 3);
         }
 
         public function admin_scripts() {


### PR DESCRIPTION
**Summary**

Our payment gateways were previously being registered on the wrong hook, which caused them to load in an inconsistent order. As a result, other plugins sometimes failed to detect our gateways or detected them only randomly.

**Changes**
	•	Moved gateway registration to the proper WordPress/WooCommerce hook (plugins_loaded after WooCommerce is available).
	•	Ensured gateway classes are loaded before being added to woocommerce_payment_gateways.
	•	Improved load order stability, preventing race conditions with third-party plugins.

**Why this fix is needed**
Loading gateways on the wrong hook led to unpredictable behavior, as other extensions could not reliably identify our payment gateways. This occasionally triggered errors such as:

<img width="1717" height="513" alt="image" src="https://github.com/user-attachments/assets/be3f1ff5-5e71-451e-8a9c-6390963a6b7c" />

**By attaching our registration logic to the correct lifecycle hook, we guarantee that:**
	•	WooCommerce classes are already loaded.
	•	Our gateways are consistently registered before other plugins interact with them.
	•	Third-party compatibility is improved.

**Testing**
	•	Verified that gateways are consistently visible under WooCommerce → Settings → Payments.
	•	Confirmed no random detection issues when used alongside other payment-related plugins.

This PR fixes the following issues:
Resolves #2111
Resolves #2117