### PR TITLE
PFW-1959 - Prevent fatal error when $this->result is not an array in PPCP Onboarding

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-admin-onboarding.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-admin-onboarding.php
@@ -138,15 +138,19 @@ class AngellEYE_PayPal_PPCP_Admin_Onboarding {
                 if (defined('PPCP_PAYPAL_COUNTRY')) {
                     $this->ppcp_paypal_country = PPCP_PAYPAL_COUNTRY;
                 }
-                if (!empty($this->result['primary_email'])) {
-                    own_angelleye_sendy_list($this->result['primary_email']);
-                    $this->email_confirm_text_1 = __('We see that your PayPal email address is', 'paypal-for-woocommerce') . ' <b>' . $this->result['primary_email'] . '</b>';
+                $primaryEmail = null;
+                if (is_array($this->result) && !empty($this->result['primary_email'])) {
+                    $primaryEmail = $this->result['primary_email'];
+                }
+                if (!empty($primaryEmail)) {
+                    own_angelleye_sendy_list($primaryEmail);
+                    $this->email_confirm_text_1 = __('We see that your PayPal email address is', 'paypal-for-woocommerce') . ' <b>' . $primaryEmail . '</b>';
                 }
                 $admin_email = get_option("admin_email");
-                if (isset($this->result['primary_email']) && $this->result['primary_email'] != $admin_email) {
+                if ($primaryEmail != $admin_email) {
                     $this->email_confirm_text_2 = __('We see that your site admin email address is', 'paypal-for-woocommerce') . ' <b>' . $admin_email . '</b>';
                 } else {
-                    $this->email_confirm_text_1 = __('We see that your email address is', 'paypal-for-woocommerce') . ' <b>' . $this->result['primary_email'] . '</b>' . ' If there is a better email to keep you informed about PayPal and payment news please let us know.';
+                    $this->email_confirm_text_1 = __('We see that your email address is', 'paypal-for-woocommerce') . ' <b>' . $primaryEmail . '</b>' . ' If there is a better email to keep you informed about PayPal and payment news please let us know.';
                 }
                 if ($this->dcc_applies->for_country_currency($this->ppcp_paypal_country) === false) {
                     $this->on_board_status = 'FULLY_CONNECTED';
@@ -174,15 +178,19 @@ class AngellEYE_PayPal_PPCP_Admin_Onboarding {
                 if (isset($this->result['country'])) {
                     $this->ppcp_paypal_country = $this->result['country'];
                 }
-                if (!empty($this->result['primary_email'])) {
-                    own_angelleye_sendy_list($this->result['primary_email']);
-                    $this->email_confirm_text_1 = __('We see that your PayPal email address is', 'paypal-for-woocommerce') . ' <b>' . $this->result['primary_email'] . '</b>';
+                $primaryEmail = null;
+                if (is_array($this->result) && !empty($this->result['primary_email'])) {
+                    $primaryEmail = $this->result['primary_email'];
+                }
+                if (!empty($primaryEmail)) {
+                    own_angelleye_sendy_list($primaryEmail);
+                    $this->email_confirm_text_1 = __('We see that your PayPal email address is', 'paypal-for-woocommerce') . ' <b>' . $primaryEmail . '</b>';
                 }
                 $admin_email = get_option("admin_email");
-                if ($this->result['primary_email'] != $admin_email) {
+                if ($primaryEmail != $admin_email) {
                     $this->email_confirm_text_2 = __('We see that your site admin email address is', 'paypal-for-woocommerce') . ' <b>' . $admin_email . '</b>';
                 } else {
-                    $this->email_confirm_text_1 = __('We see that your email address is', 'paypal-for-woocommerce') . ' <b>' . $this->result['primary_email'] . '</b>' . ' If there is a better email to keep you informed about PayPal and payment news please let us know.';
+                    $this->email_confirm_text_1 = __('We see that your email address is', 'paypal-for-woocommerce') . ' <b>' . $primaryEmail . '</b>' . ' If there is a better email to keep you informed about PayPal and payment news please let us know.';
                 }
                 if ($this->dcc_applies->for_country_currency($this->ppcp_paypal_country) === false) {
                     $this->on_board_status = 'FULLY_CONNECTED';
@@ -678,7 +686,7 @@ class AngellEYE_PayPal_PPCP_Admin_Onboarding {
                             <?php } ?>
                             <br>
                             <div class="ppcp_sendy_confirm_parent">
-                                <input type="text" class="ppcp_sendy_confirm" id="angelleye_ppcp_sendy_email" placeholder="Your Email Address" value="<?php echo!empty($this->result['primary_email']) ? $this->result['primary_email'] : '' ?>">
+                                <input type="text" class="ppcp_sendy_confirm" id="angelleye_ppcp_sendy_email" placeholder="Your Email Address" value="<?php echo is_array($this->result) && !empty($this->result['primary_email']) ? $this->result['primary_email'] : '' ?>">
                                 <button id="angelleye_ppcp_email_confirm" type="button" class="button button-primary button-primary-own"><?php echo __('Submit', 'paypal-for-woocommerce'); ?></button>
                             </div>
                             <div id="angelleye_ppcp_sendy_msg"></div>

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-seller-onboarding.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-seller-onboarding.php
@@ -610,7 +610,7 @@ class AngellEYE_PayPal_PPCP_Seller_Onboarding {
                 }
                 $this->setting_obj->persist();
                 $this->result = $this->angelleye_track_seller_onboarding_status($seller_onboarding_status['merchant_id']);
-                if (!empty($this->result['primary_email'])) {
+                if (is_array($this->result) && !empty($this->result['primary_email'])) {
                     own_angelleye_sendy_list($this->result['primary_email']);
                 }
                 if (angelleye_is_acdc_payments_enable($this->result)) {


### PR DESCRIPTION
This PR fixes a fatal error occurring in the PPCP Admin Onboarding flow when `$this->result` is unexpectedly a string instead of an array.

Previously, code attempted to directly access `$this->result['primary_email']`, which caused:

`TypeError: Cannot access offset of type string on string`

This happened because isset() or empty() still attempt array offset access even when $this->result is not an array.

**Changes Made**
	•	Added a type guard `(is_array($this->result))` before attempting to access `['primary_email']`.
	•	Ensured primary_email is only used when `$this->result` is an array and the value is non-empty.

**How it Fixes**
	•	Prevents runtime fatal error when $this->result is not in the expected format.
	•	Makes the code more robust against unexpected API responses or assignment issues.
	•	Improves stability of the onboarding flow in admin pages.