### PR TITLE
Venmo button issue fix for US users

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -560,10 +560,8 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
                 array_push($enable_funding, 'ideal');
             }
 
-            if ($this->is_sandbox) {
-                if (is_user_logged_in() && WC()->customer && WC()->customer->get_billing_country() && 2 === strlen(WC()->customer->get_billing_country())) {
-                    $smart_js_arg['buyer-country'] = WC()->customer->get_billing_country();
-                }
+            if (is_user_logged_in() && WC()->customer && WC()->customer->get_billing_country() && 2 === strlen(WC()->customer->get_billing_country())) {
+                $smart_js_arg['buyer-country'] = WC()->customer->get_billing_country();
             }
             $product_cart_amounts = $this->payment_request->ae_get_updated_checkout_payment_data();
 

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -560,7 +560,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
                 array_push($enable_funding, 'ideal');
             }
 
-            if (is_user_logged_in() && WC()->customer && WC()->customer->get_billing_country() && 2 === strlen(WC()->customer->get_billing_country())) {
+            if (WC()->customer && WC()->customer->get_billing_country() && 2 === strlen(WC()->customer->get_billing_country())) {
                 $smart_js_arg['buyer-country'] = WC()->customer->get_billing_country();
             }
             $product_cart_amounts = $this->payment_request->ae_get_updated_checkout_payment_data();


### PR DESCRIPTION
## Issue
Venmo button is not appearing for US customers in Live mode.

## Description
This PR addresses an issue where the **Venmo payment button was not appearing for US customers when the gateway was in Live mode**. The expected behavior is that Venmo should be displayed for eligible US customers when it is enabled in the PayPal settings.

## Changes
- Implemented fixes to ensure the **Venmo button renders correctly in Live mode** for eligible US customers.
- Ensured proper eligibility handling so that Venmo appears when conditions are met.

## Testing
- Enabled Venmo in PayPal for WooCommerce settings.
- Switched the gateway to **Live mode**.
- Verified that the **Venmo button appears correctly for US customers** on the checkout page.

## Related Issue
Fixes: Venmo button not appearing for US customers in Live mode