### PR TITLE
Fix ACDC - Credit & Debit Card spinner not hiding on cart & checkout

### DIFF
--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -566,7 +566,9 @@ const angelleyeOrder = {
                     angelleyeJsErrorLogger.addToLog(errorLogId, 'PayPal Smart Button Payment Started');
                     return angelleyeOrder.createSmartButtonOrder({
                         angelleye_ppcp_button_selector, errorLogId
-                    })
+                    }).finally(() => {
+                        angelleyeOrder.hideProcessingSpinner();
+                    });
                 },
                 onApprove: function (data, actions) {
                     angelleyeOrder.showProcessingSpinner();


### PR DESCRIPTION
Closes Issue: #2153 

**Description:**

This PR fixes an issue where the processing spinner would remain visible when the Credit & Debit Card option was selected during checkout. Because the spinner did not hide, the card fields never became accessible, preventing users from entering their card details and completing the payment.

**Changes**
	•	Ensured the spinner properly hides once the card fields are initialized.
	•	Prevented the UI from remaining in a loading state when rendering Credit & Debit Card fields.

**Result**
Customers can now successfully access and enter their credit or debit card details without the spinner blocking the form.