### PR TITLE
Refactor push notification handling in AngellEYE_Utility class #2160

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -2242,7 +2242,7 @@ class AngellEYE_Utility {
         $api_url .= '&action=angelleye_get_plugin_notification';
         $request = wp_remote_post($api_url, array(
             'method' => 'POST',
-            'timeout' => 10,
+            'timeout' => 4,
             'redirection' => 5,
             'httpversion' => '1.0',
             'blocking' => true,

--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -2222,15 +2222,27 @@ class AngellEYE_Utility {
         }
     }
 
-    public static function angelleye_get_push_notifications() {
+    public static function angelleye_get_push_notifications($plugin_name = 'paypal-for-woocommerce') {
+        $success_transient_key = self::angelleye_get_push_notification_success_transient_key($plugin_name);
+        $failure_transient_key = self::angelleye_get_push_notification_failure_transient_key($plugin_name);
+
+        $cached_response = get_transient($success_transient_key);
+        if (false !== $cached_response) {
+            return $cached_response;
+        }
+
+        if (false !== get_transient($failure_transient_key)) {
+            return false;
+        }
+
         $args = array(
-            'plugin_name' => 'paypal-for-woocommerce',
+            'plugin_name' => $plugin_name,
         );
         $api_url = PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL . '?Wordpress_Plugin_Notification_Sender';
         $api_url .= '&action=angelleye_get_plugin_notification';
         $request = wp_remote_post($api_url, array(
             'method' => 'POST',
-            'timeout' => 45,
+            'timeout' => 10,
             'redirection' => 5,
             'httpversion' => '1.0',
             'blocking' => true,
@@ -2240,6 +2252,7 @@ class AngellEYE_Utility {
             'sslverify' => false
         ));
         if (is_wp_error($request) or wp_remote_retrieve_response_code($request) != 200) {
+            set_transient($failure_transient_key, time(), 4 * HOUR_IN_SECONDS);
             return false;
         }
         if ($request != '') {
@@ -2247,7 +2260,21 @@ class AngellEYE_Utility {
         } else {
             $response = false;
         }
+        if ($response) {
+            set_transient($success_transient_key, $response, 12 * HOUR_IN_SECONDS);
+            delete_transient($failure_transient_key);
+        } else {
+            set_transient($failure_transient_key, time(), 4 * HOUR_IN_SECONDS);
+        }
         return $response;
+    }
+
+    private static function angelleye_get_push_notification_success_transient_key($plugin_name) {
+        return 'angelleye_push_notification_success_' . md5($plugin_name);
+    }
+
+    private static function angelleye_get_push_notification_failure_transient_key($plugin_name) {
+        return 'angelleye_push_notification_failure_' . md5($plugin_name);
     }
 
     public static function angelleye_display_push_notification($response_data) {

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -386,12 +386,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
                 }
             }
 
-            if (false === ($response = get_transient('angelleye_push_notification_result'))) {
-                $response = AngellEYE_Utility::angelleye_get_push_notifications();
-                if (is_object($response)) {
-                    set_transient('angelleye_push_notification_result', $response, 12 * HOUR_IN_SECONDS);
-                }
-            }
+            $response = AngellEYE_Utility::angelleye_get_push_notifications('paypal-for-woocommerce');
             if (is_object($response)) {
                 foreach ($response->data as $key => $response_data) {
                     $display = false;


### PR DESCRIPTION
## Description
This PR addresses the 20-second admin load time reported in #2160. The root cause was identified as a high timeout (45s) in `angelleye_get_push_notifications()` without proper transient caching when the API host was unreachable.

## Changes
* **Implemented Transient Caching:** * Successful API responses are now cached for 12 hours.
    * Failed requests (timeouts or non-200 codes) now trigger a "failure transient" for 4 hours to prevent repeated blocking of the admin UI.
* **Reduced Timeout:** Lowered the `wp_remote_post` timeout from 45 seconds to 10 seconds.
* **Refactored Utility Class:** Moved caching logic directly into `angelleye_get_push_notifications` and added helper methods for dynamic transient keys based on the plugin name.
* **Cleaned up Main File:** Simplified `admin_notices()` in the main plugin file to offload logic to the Utility class.

## Testing Instructions
1. Navigate to the WordPress Admin dashboard.
2. Verify that the admin notice still appears if the API is reachable.
3. Simulate a connection failure (e.g., via firewall or temporary URL change). Verify the page does not hang for more than 10 seconds on the first load, and loads instantly on subsequent refreshes due to the failure transient.

Fixes #2160