### PR TITLE
PFWST Compatibility: Resolves class load error, Preserves Parent PayPal Order ID in FunnelKit Batching (PPCP + PPCP-CC)

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -2242,7 +2242,7 @@ class AngellEYE_Utility {
         $api_url .= '&action=angelleye_get_plugin_notification';
         $request = wp_remote_post($api_url, array(
             'method' => 'POST',
-            'timeout' => 10,
+            'timeout' => 4,
             'redirection' => 5,
             'httpversion' => '1.0',
             'blocking' => true,

--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -2222,15 +2222,27 @@ class AngellEYE_Utility {
         }
     }
 
-    public static function angelleye_get_push_notifications() {
+    public static function angelleye_get_push_notifications($plugin_name = 'paypal-for-woocommerce') {
+        $success_transient_key = self::angelleye_get_push_notification_success_transient_key($plugin_name);
+        $failure_transient_key = self::angelleye_get_push_notification_failure_transient_key($plugin_name);
+
+        $cached_response = get_transient($success_transient_key);
+        if (false !== $cached_response) {
+            return $cached_response;
+        }
+
+        if (false !== get_transient($failure_transient_key)) {
+            return false;
+        }
+
         $args = array(
-            'plugin_name' => 'paypal-for-woocommerce',
+            'plugin_name' => $plugin_name,
         );
         $api_url = PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL . '?Wordpress_Plugin_Notification_Sender';
         $api_url .= '&action=angelleye_get_plugin_notification';
         $request = wp_remote_post($api_url, array(
             'method' => 'POST',
-            'timeout' => 45,
+            'timeout' => 10,
             'redirection' => 5,
             'httpversion' => '1.0',
             'blocking' => true,
@@ -2240,6 +2252,7 @@ class AngellEYE_Utility {
             'sslverify' => false
         ));
         if (is_wp_error($request) or wp_remote_retrieve_response_code($request) != 200) {
+            set_transient($failure_transient_key, time(), 4 * HOUR_IN_SECONDS);
             return false;
         }
         if ($request != '') {
@@ -2247,7 +2260,21 @@ class AngellEYE_Utility {
         } else {
             $response = false;
         }
+        if ($response) {
+            set_transient($success_transient_key, $response, 12 * HOUR_IN_SECONDS);
+            delete_transient($failure_transient_key);
+        } else {
+            set_transient($failure_transient_key, time(), 4 * HOUR_IN_SECONDS);
+        }
         return $response;
+    }
+
+    private static function angelleye_get_push_notification_success_transient_key($plugin_name) {
+        return 'angelleye_push_notification_success_' . md5($plugin_name);
+    }
+
+    private static function angelleye_get_push_notification_failure_transient_key($plugin_name) {
+        return 'angelleye_push_notification_failure_' . md5($plugin_name);
     }
 
     public static function angelleye_display_push_notification($response_data) {

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -1660,6 +1660,51 @@ if (!function_exists('angelleye_pfw_is_ppcp_runtime_ready')) {
     }
 }
 
+if (!function_exists('angelleye_pfw_get_ppcp_settings')) {
+    /**
+     * Read PPCP settings directly from options without bootstrapping PPCP classes.
+     *
+     * @param string|null $key     Optional settings key.
+     * @param mixed       $default Default value when key is missing.
+     * @return mixed
+     */
+    function angelleye_pfw_get_ppcp_settings($key = null, $default = null) {
+        $settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+        if (!is_array($settings)) {
+            $settings = array();
+        }
+        if ($key === null) {
+            return $settings;
+        }
+        return array_key_exists($key, $settings) ? $settings[$key] : $default;
+    }
+}
+
+if (!function_exists('angelleye_pfw_get_ppcp_mode')) {
+    /**
+     * Return normalized PPCP mode flags based on stored options only.
+     *
+     * @return array
+     */
+    function angelleye_pfw_get_ppcp_mode() {
+        $sandbox = 'yes' === angelleye_pfw_get_ppcp_settings('testmode', 'no');
+        $sandbox_client_id = (string) angelleye_pfw_get_ppcp_settings('sandbox_client_id', '');
+        $sandbox_secret_id = (string) angelleye_pfw_get_ppcp_settings('sandbox_api_secret', '');
+        $sandbox_merchant_id = (string) angelleye_pfw_get_ppcp_settings('sandbox_merchant_id', '');
+        $live_client_id = (string) angelleye_pfw_get_ppcp_settings('api_client_id', '');
+        $live_secret_id = (string) angelleye_pfw_get_ppcp_settings('api_secret', '');
+        $live_merchant_id = (string) angelleye_pfw_get_ppcp_settings('live_merchant_id', '');
+
+        return array(
+            'sandbox' => $sandbox,
+            'sandbox_first_party' => (!empty($sandbox_client_id) && !empty($sandbox_secret_id)),
+            'sandbox_third_party' => (empty($sandbox_client_id) || empty($sandbox_secret_id)) && !empty($sandbox_merchant_id),
+            'live_first_party' => (!empty($live_client_id) && !empty($live_secret_id)),
+            'live_third_party' => (empty($live_client_id) || empty($live_secret_id)) && !empty($live_merchant_id),
+        );
+    }
+}
+
 add_action('before_woocommerce_init', function () {
     if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
         \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -571,6 +571,9 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
         }
 
         public function angelleye_add_paypal_pro_gateway($methods) {
+            // Ensure PPCP traits/classes are loaded before any direct gateway class includes.
+            $this->bootstrap_ppcp_runtime();
+
             if (class_exists('WC_Subscriptions') && function_exists('wcs_create_renewal_order')) {
                 $this->subscription_support_enabled = true;
             }

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -86,7 +86,6 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
                 'PAYPAL_PPCP_SANDBOX_PARTNER_CLIENT_ID' => 'AaYsUf4lXeKOnLmKhDWbak0YYWNk5SW0Lt1lk22gFvsgu74h1Vawg1y6rcmt60f8JIx-x81J5bMA-q7O',
                 'PAYPAL_PPCP_PARTNER_CLIENT_ID' => 'ATgw55qRjaDSlPur2FAkdAiB-QQuG5jlLsees-8dcxLiLla_nwbBSvSnCbUaGlmzxq9t2b8R9JGGSz1e',
                 'PAYPAL_FOR_WOOCOMMERCE_PPCP_AWS_WEB_SERVICE' => 'https://zpyql2kd39.execute-api.us-east-2.amazonaws.com/production/PayPalMerchantIntegration/',
-                // 'PAYPAL_FOR_WOOCOMMERCE_PPCP_AWS_WEB_SERVICE' => 'https://3yjtbtgz0m.execute-api.us-east-2.amazonaws.com/default/PayPalMerchantIntegrationTest/',
                 'PAYPAL_FOR_WOOCOMMERCE_PPCP_ANGELLEYE_WEB_SERVICE' => 'https://ppcp.angelleye.com/production/PayPalMerchantIntegration/',
                 'AE_FEE' => 'ae_p_f',
                 'AE_PPCP_NAME' => 'PayPal Complete Payments',

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -386,12 +386,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
                 }
             }
 
-            if (false === ($response = get_transient('angelleye_push_notification_result'))) {
-                $response = AngellEYE_Utility::angelleye_get_push_notifications();
-                if (is_object($response)) {
-                    set_transient('angelleye_push_notification_result', $response, 12 * HOUR_IN_SECONDS);
-                }
-            }
+            $response = AngellEYE_Utility::angelleye_get_push_notifications('paypal-for-woocommerce');
             if (is_object($response)) {
                 foreach ($response->data as $key => $response_data) {
                     $display = false;

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -130,6 +130,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             add_action('wp', array(__CLASS__, 'angelleye_delete_payment_method_action'), 10);
             add_action('init', array($this, 'angelleye_register_post_status'), 99);
             add_action('current_screen', array($this, 'angelleye_redirect_to_onboard'), 9);
+            add_filter('woocommerce_payment_gateways', array($this, 'angelleye_add_paypal_pro_gateway'), 1000);
             add_action('init', [$this, 'include_gateway_in_list'], 1000);
             add_filter('rest_request_after_callbacks', array($this, 'angelleye_filter_wcadmin_payments_providers_response'), 10, 3);
         }
@@ -275,7 +276,6 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
 
         public function include_gateway_in_list() {
             $this->init();
-            add_filter('woocommerce_payment_gateways', array($this, 'angelleye_add_paypal_pro_gateway'), 1000);
         }
 
         private function include_files_and_classes() {

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -1609,6 +1609,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             try {
                 // Check for Funnel Builder Pro Plugin Activation
                 if (defined('WFFN_PRO_FILE')) {
+                    require_once plugin_dir_path(__FILE__) . 'ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php';
                     require_once plugin_dir_path(__FILE__) . 'ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php';
                     require_once plugin_dir_path(__FILE__) . 'ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php';
                 }

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -42,6 +42,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
         protected $plugin_screen_hook_suffix = null;
         protected $plugin_slug = 'paypal-for-woocommerce';
         private $subscription_support_enabled = false;
+        private $ppcp_runtime_bootstrapped = false;
         public $minified_version;
         public $use_wp_locale_code;
         public $customer_id = '';
@@ -85,6 +86,7 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
                 'PAYPAL_PPCP_SANDBOX_PARTNER_CLIENT_ID' => 'AaYsUf4lXeKOnLmKhDWbak0YYWNk5SW0Lt1lk22gFvsgu74h1Vawg1y6rcmt60f8JIx-x81J5bMA-q7O',
                 'PAYPAL_PPCP_PARTNER_CLIENT_ID' => 'ATgw55qRjaDSlPur2FAkdAiB-QQuG5jlLsees-8dcxLiLla_nwbBSvSnCbUaGlmzxq9t2b8R9JGGSz1e',
                 'PAYPAL_FOR_WOOCOMMERCE_PPCP_AWS_WEB_SERVICE' => 'https://zpyql2kd39.execute-api.us-east-2.amazonaws.com/production/PayPalMerchantIntegration/',
+                // 'PAYPAL_FOR_WOOCOMMERCE_PPCP_AWS_WEB_SERVICE' => 'https://3yjtbtgz0m.execute-api.us-east-2.amazonaws.com/default/PayPalMerchantIntegrationTest/',
                 'PAYPAL_FOR_WOOCOMMERCE_PPCP_ANGELLEYE_WEB_SERVICE' => 'https://ppcp.angelleye.com/production/PayPalMerchantIntegration/',
                 'AE_FEE' => 'ae_p_f',
                 'AE_PPCP_NAME' => 'PayPal Complete Payments',
@@ -424,6 +426,35 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             } else {
                 include_once plugin_dir_path(__FILE__) . 'angelleye-includes/express-checkout/class-wc-gateway-paypal-express-helper-angelleye-v2.php';
             }
+            $this->bootstrap_ppcp_runtime();
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-payflow-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-advanced-angelleye.php');
+            if (is_angelleye_multi_account_active()) {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v1.php');
+            } else {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v2.php');
+            }
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-braintree-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php');
+            AngellEYE_PayPal_PPCP_Smart_Button::instance();
+            Angelleye_PayPal_Express_Checkout_Helper::instance();
+            AngellEYE_PayPal_PPCP_Seller_Onboarding::instance();
+            AngellEYE_PayPal_PPCP_Pay_Later::instance();
+            AngellEYE_PayPal_PPCP_Admin_Action::instance();
+            AngellEYE_PayPal_PPCP_Front_Action::instance();
+            AngellEye_PayPal_PPCP_Apple_Domain_Validation::instance();
+            AngellEye_Session_Manager::instance();
+        }
+
+        /**
+         * Load PPCP runtime dependencies once and expose a shared readiness hook for dependent plugins.
+         */
+        public function bootstrap_ppcp_runtime() {
+            if ($this->ppcp_runtime_bootstrapped) {
+                return;
+            }
+
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/includes/ae-ppcp-constants.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/includes/trait-angelleye-ppcp-core.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/pre-order/trait-wc-ppcp-pre-orders.php');
@@ -435,30 +466,24 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-pay-later-messaging.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-admin-action.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php');
-            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-payflow-angelleye.php');
-            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-advanced-angelleye.php');
-            if (is_angelleye_multi_account_active()) {
-                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v1.php');
-            } else {
-                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v2.php');
-            }
-            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-angelleye.php');
-            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-braintree-angelleye.php');
-            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-cc-angelleye.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-apple-pay-angelleye.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-google-pay-angelleye.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/lib/class-angelleye-wordpress-custom-routes-handler.php');
             include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/includes/class-angelleye-paypal-ppcp-apple-domain-validation.php');
-            AngellEYE_PayPal_PPCP_Smart_Button::instance();
-            Angelleye_PayPal_Express_Checkout_Helper::instance();
-            AngellEYE_PayPal_PPCP_Seller_Onboarding::instance();
-            AngellEYE_PayPal_PPCP_Pay_Later::instance();
-            AngellEYE_PayPal_PPCP_Admin_Action::instance();
-            AngellEYE_PayPal_PPCP_Front_Action::instance();
-            AngellEye_PayPal_PPCP_Apple_Domain_Validation::instance();
-            AngellEye_Session_Manager::instance();
+
+            $this->ppcp_runtime_bootstrapped = true;
+            do_action('angelleye_pfw_ppcp_runtime_ready');
+        }
+
+        /**
+         * Check whether PPCP runtime dependencies are already loaded in the current request.
+         *
+         * @return bool
+         */
+        public function is_ppcp_runtime_ready() {
+            return $this->ppcp_runtime_bootstrapped;
         }
 
         public function admin_scripts() {
@@ -1609,7 +1634,27 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
 
 }
 
-new AngellEYE_Gateway_Paypal();
+global $angelleye_gateway_paypal_instance;
+$angelleye_gateway_paypal_instance = new AngellEYE_Gateway_Paypal();
+
+if (!function_exists('angelleye_pfw_bootstrap_ppcp_runtime')) {
+    function angelleye_pfw_bootstrap_ppcp_runtime() {
+        global $angelleye_gateway_paypal_instance;
+        if ($angelleye_gateway_paypal_instance instanceof AngellEYE_Gateway_Paypal) {
+            $angelleye_gateway_paypal_instance->bootstrap_ppcp_runtime();
+        }
+    }
+}
+
+if (!function_exists('angelleye_pfw_is_ppcp_runtime_ready')) {
+    function angelleye_pfw_is_ppcp_runtime_ready() {
+        global $angelleye_gateway_paypal_instance;
+        if ($angelleye_gateway_paypal_instance instanceof AngellEYE_Gateway_Paypal) {
+            return $angelleye_gateway_paypal_instance->is_ppcp_runtime_ready();
+        }
+        return false;
+    }
+}
 
 add_action('before_woocommerce_init', function () {
     if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -2,6 +2,16 @@
 
 defined('ABSPATH') || exit;
 
+if (!trait_exists('WC_PPCP_Pre_Orders_Trait')) {
+    if (function_exists('angelleye_pfw_bootstrap_ppcp_runtime')) {
+        angelleye_pfw_bootstrap_ppcp_runtime();
+    }
+
+    if (!trait_exists('WC_PPCP_Pre_Orders_Trait') && defined('PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR')) {
+        include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/pre-order/trait-wc-ppcp-pre-orders.php';
+    }
+}
+
 class AngellEYE_PayPal_PPCP_Payment {
 
     use WC_PPCP_Pre_Orders_Trait;

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
@@ -414,8 +414,10 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                         $is_successful = false;
                         WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to create paypal Order refer error below' . print_r($ppcp_resp, true));
                     } else {
-                        $order->update_meta_data('_paypal_order_id', $ppcp_resp['id']);
-                        $order->save();
+                        if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode() === false) {
+                            $order->update_meta_data('_paypal_order_id', $ppcp_resp['id']);
+                            $order->save();
+                        }
                         $this->payal_order_id = $ppcp_resp['id'];
                         if ('COMPLETED' == $ppcp_resp['status']) {
                             $get_order->update_meta_data('wfocu_ppcp_order_current', $ppcp_resp['id']);
@@ -423,6 +425,9 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                             WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal Order successfully created');
                             $transaction_id = $ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'];
                             WFOCU_Core()->data->set('_transaction_id', $transaction_id);
+                            if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
+                                WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $ppcp_resp, $transaction_id, $get_current_offer, 'angelleye_ppcp_cc');
+                            }
                             $is_successful = true;
                         } else {
                             $is_successful = false;

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
@@ -1,0 +1,48 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper')) {
+    class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper {
+
+        public static function is_wfocu_batching_mode() {
+            try {
+                $order_behavior = WFOCU_Core()->funnels->get_funnel_option('order_behavior');
+                return ('batching' === $order_behavior);
+            } catch (Exception $ex) {
+                return false;
+            }
+        }
+
+        public static function store_wfocu_batching_upsell_payment($parent_order, $ppcp_resp, $transaction_id, $offer_id, $gateway) {
+            try {
+                if (!is_a($parent_order, 'WC_Order')) {
+                    return;
+                }
+
+                $existing = $parent_order->get_meta('_angelleye_wfocu_ppcp_upsell_payments', true);
+                if (!is_array($existing)) {
+                    $existing = array();
+                }
+
+                $existing[] = array(
+                    'gateway' => $gateway,
+                    'funnel_id' => WFOCU_Core()->data->get_funnel_id(),
+                    'offer_id' => $offer_id,
+                    'paypal_order_id' => isset($ppcp_resp['id']) ? $ppcp_resp['id'] : '',
+                    'capture_id' => $transaction_id,
+                    'transaction_id' => $transaction_id,
+                    'status' => isset($ppcp_resp['status']) ? $ppcp_resp['status'] : '',
+                    'created_at' => time(),
+                );
+
+                $parent_order->update_meta_data('_angelleye_wfocu_ppcp_upsell_payments', $existing);
+                $parent_order->save();
+            } catch (Exception $ex) {
+                
+            }
+        }
+    }
+}

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -479,8 +479,10 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                         $is_successful = false;
                         WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to create paypal Order refer error below' . print_r($ppcp_resp, true));
                     } else {
-                        $order->update_meta_data('_paypal_order_id', $ppcp_resp['id']);
-                        $order->save();
+                        if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode() === false) {
+                            $order->update_meta_data('_paypal_order_id', $ppcp_resp['id']);
+                            $order->save();
+                        }
                         $this->payal_order_id = $ppcp_resp['id'];
                         if ('COMPLETED' == $ppcp_resp['status']) {
                             $get_order->update_meta_data('wfocu_ppcp_order_current', $ppcp_resp['id']);
@@ -488,6 +490,9 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                             WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal Order successfully created');
                             $transaction_id = $ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'];
                             WFOCU_Core()->data->set('_transaction_id', $transaction_id);
+                            if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
+                                WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $ppcp_resp, $transaction_id, $get_current_offer, 'angelleye_ppcp');
+                            }
                             add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
                             add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
                             $this->payal_order_id = $ppcp_resp['id'];


### PR DESCRIPTION
### Summary
- Load the class files in right order to support our plugins such as PFWST, PFWMA
- Fix FunnelKit upsell batching so accepted upsells do not overwrite the parent order’s original `_paypal_order_id`.  
Instead, store each upsell’s PayPal order/capture details in a dedicated append-only parent-order meta array, while keeping existing create-order flow behavior intact.

### What changed
- Updated class file loading order
- Updated tokenized upsell `process_charge()` in:
  - [class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php](/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php)
  - [class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php](/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php)

- Added batching behavior check (`order_behavior === 'batching'`) in both classes.
- In batching mode, stopped overwriting parent `_paypal_order_id`.
- In non-batching mode, existing `_paypal_order_id` behavior is preserved.
- Added append-only parent-order meta storage under:
  - `_angelleye_wfocu_ppcp_upsell_payments`
- Each accepted upsell appends a record with:
  - `gateway`, `funnel_id`, `offer_id`, `paypal_order_id`, `capture_id`, `transaction_id`, `status`, `created_at`.

### Notes
- `wfocu_ppcp_order_current` and WFOCU `_transaction_id` flow remains unchanged.
- Existing FunnelKit event-tracking hooks/meta behavior remains unchanged.