### PR TITLE
Added PFWST individual line item shipment tracking compatibility with FunnelKit upsell items with PPCP payments

### DIFF
--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
@@ -468,7 +468,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                 $get_order->save();
             }
         } catch (Exception $ex) {
-            
+
         }
     }
 

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
@@ -36,12 +36,41 @@ if (!class_exists('WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper')) {
                     'transaction_id' => $transaction_id,
                     'status' => isset($ppcp_resp['status']) ? $ppcp_resp['status'] : '',
                     'created_at' => time(),
+                    'order_item_ids' => array(),
                 );
 
                 $parent_order->update_meta_data('_angelleye_wfocu_ppcp_upsell_payments', $existing);
                 $parent_order->save();
+
+                // Hook into wfocu_offer_accepted_and_processed (fires in both batching and non-batching modes)
+                // to capture the WC order item IDs added for this upsell and store them against the capture.
+                $parent_order_id = $parent_order->get_id();
+                $stored_transaction_id = $transaction_id;
+                add_action('wfocu_offer_accepted_and_processed', function($offer_id, $package, $porder, $new_order, $txn_id, $items_added) use ($parent_order_id, $stored_transaction_id) {
+                    if ($txn_id !== $stored_transaction_id) {
+                        return;
+                    }
+                    $parent_order = wc_get_order($parent_order_id);
+                    if (!is_a($parent_order, 'WC_Order')) {
+                        return;
+                    }
+                    $existing = $parent_order->get_meta('_angelleye_wfocu_ppcp_upsell_payments', true);
+                    if (!is_array($existing)) {
+                        return;
+                    }
+                    foreach ($existing as &$entry) {
+                        if (isset($entry['capture_id']) && $entry['capture_id'] === $stored_transaction_id) {
+                            $entry['order_item_ids'] = is_array($items_added) ? $items_added : array();
+                            break;
+                        }
+                    }
+                    unset($entry);
+                    $parent_order->update_meta_data('_angelleye_wfocu_ppcp_upsell_payments', $existing);
+                    $parent_order->save();
+                }, 20, 6);
+
             } catch (Exception $ex) {
-                
+
             }
         }
     }

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -406,7 +406,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
     public function process_charge($order) {
         try {
             if ($this->enable_tokenized_payments) {
-                WFOCU_Core()->log->log('process charge paypal advanced credit card');
+                WFOCU_Core()->log->log('process charge paypal PPCP');
                 $is_successful = false;
                 $get_current_offer = WFOCU_Core()->data->get('current_offer');
                 $get_current_offer_meta = WFOCU_Core()->offers->get_offer_meta($get_current_offer);
@@ -537,7 +537,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                 $get_order->save();
             }
         } catch (Exception $ex) {
-            
+
         }
     }
 


### PR DESCRIPTION
**Title:** Store WC order item IDs in upsell payment meta for PPCP FunnelKit batching mode

## Summary

- Added `wfocu_offer_accepted_and_processed` hook inside `store_wfocu_batching_upsell_payment()` to capture the WC line item IDs added to the parent order during upsell acceptance
- Item IDs are stored as `order_item_ids` in the corresponding entry of `_angelleye_wfocu_ppcp_upsell_payments` order meta, keyed by `capture_id`
- This works correctly in batching mode where items are added directly to the parent order (not a new sub-order)

## Files Changed

- `ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php`

## Test Plan

- [ ] Place a PPCP order with FunnelKit upsell enabled in batching mode
- [ ] Accept the upsell offer
- [ ] Verify `_angelleye_wfocu_ppcp_upsell_payments` on the parent order contains `order_item_ids` array with the correct WC item ID(s)
- [ ] Confirm no regression for orders without upsells
