### PR TITLE
fix: Add FunnelKit support on product/cart page checkouts when tokenization enabled

### DIFF
--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -824,6 +824,15 @@ if (!function_exists('angelleye_ppcp_is_save_payment_method')) {
                 break;
             }
         }
+        // When tokenization is enabled and request originates from product/cart page
+        // (or checkout_top), the save-payment-method checkbox is not in the serialized
+        // form data. Force vault so the token is stored with the order.
+        if ( ! $is_enable && $enable_tokenized_payments === true ) {
+            $request_from = isset( $_GET['from'] ) ? sanitize_text_field( $_GET['from'] ) : '';
+            if ( ! in_array( $request_from, array( 'checkout', 'pay_page' ), true ) ) {
+                $is_enable = true;
+            }
+        }
 
         return apply_filters('angelleye_ppcp_is_save_payment_method', $is_enable);
     }


### PR DESCRIPTION
### fix: add `store_in_vault` to create_order requests from product and cart pages

#### Problem

When a user clicks the PayPal smart button on a **product or cart page** with tokenized payments enabled, the `create_order` API request to PayPal never includes `payment_source` with `store_in_vault`. The payment method is never vaulted, breaking tokenization for non-checkout origins.

#### Root Cause

`angelleye_ppcp_is_save_payment_method()` only returns `true` when:

1. Cart contains a subscription AND tokenization is enabled
2. `wc-angelleye_ppcp-new-payment-method` POST field is `'true'`

Condition 2 **never fires from product/cart pages** because:
- Product page serializes `form.cart`
- Cart page serializes `form.woocommerce-cart-form`
- Neither form contains the `wc-angelleye_ppcp-new-payment-method` field — it only exists in the WooCommerce checkout form rendered via `payment_fields()`

#### Fix

Added a third condition in `angelleye_ppcp_is_save_payment_method()`: when `enable_tokenized_payments` is `true` and the request does **not** originate from `checkout` or `pay_page` (where the POST field already handles it), force vault.

```diff
+ if ( ! $is_enable && $enable_tokenized_payments === true ) {
+     $request_from = isset( $_GET['from'] ) ? sanitize_text_field( $_GET['from'] ) : '';
+     if ( ! in_array( $request_from, array( 'checkout', 'pay_page' ), true ) ) {
+         $is_enable = true;
+     }
+ }
