### PR TITLE
fix: resolve MAX_CAPTURE_AMOUNT_EXCEEDED when capturing authorized orders with FunnelKit upsells

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -2924,6 +2924,47 @@ class AngellEYE_PayPal_PPCP_Payment {
             $body_request = angelleye_ppcp_remove_empty_key($capture_arg);
             $body_request['final_capture'] = $final_capture;
             $authorization_id = angelleye_ppcp_get_post_meta($order, '_auth_transaction_id');
+            // FunnelKit upsells are always captured immediately (separate PayPal order with CAPTURE intent).
+            // Exclude upsell items/amounts from the parent authorization capture to avoid MAX_CAPTURE_AMOUNT_EXCEEDED.
+            $upsell_payments = $order->get_meta('_angelleye_wfocu_ppcp_upsell_payments', true);
+            $upsell_captured_total = 0;
+            if (!empty($upsell_payments) && is_array($upsell_payments)) {
+                foreach ($upsell_payments as $upsell) {
+                    $upsell_item_ids = $upsell['order_item_ids'] ?? [];
+                    $upsell_amount = floatval($upsell['amount'] ?? 0);
+                    // Remove upsell items from parent capture line items
+                    if (!empty($upsell_item_ids)) {
+                        foreach ($upsell_item_ids as $item_id) {
+                            unset($order_data['refund_line_total'][$item_id]);
+                        }
+                    } elseif ($upsell_amount > 0) {
+                        // Fallback: order_item_ids empty — track amount to subtract from parent
+                        $upsell_captured_total += $upsell_amount;
+                    }
+                }
+                // Recalculate parent capture amount from remaining items
+                $remaining_amount = 0;
+                foreach ($order_data['refund_line_total'] as $item_amount) {
+                    if (!empty($item_amount)) {
+                        $remaining_amount += floatval($item_amount);
+                    }
+                }
+                // If order_item_ids were empty, subtract upsell amounts from remaining
+                if ($upsell_captured_total > 0 && $remaining_amount > 0) {
+                    $remaining_amount -= $upsell_captured_total;
+                    if ($remaining_amount < 0) {
+                        $remaining_amount = 0;
+                    }
+                }
+                if ($remaining_amount <= 0) {
+                    // All items were upsell items — no parent capture needed
+                    $order->add_order_note(__('All items are FunnelKit upsells already captured. No parent authorization capture needed.', 'paypal-for-woocommerce'));
+                    return;
+                }
+                // Update parent capture amount to only cover remaining (non-upsell) items
+                $amount_value = wc_format_decimal($remaining_amount, wc_get_price_decimals());
+                $body_request['amount']['value'] = $amount_value;
+            }
             $args = array(
                 'method' => 'POST',
                 'timeout' => 60,

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
@@ -137,7 +137,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
             WFOCU_Core()->data->set('_upsell_package', $existing_package);
             if (isset($resp_body['status']) && 'failed' === $resp_body['status']) {
                 $data = WFOCU_Core()->process_offer->_handle_upsell_charge(false);
-                WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to capture paypal Order refer error below' . print_r($resp_body, true));
+                WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to capture paypal CC Order refer error below' . print_r($resp_body, true));
             } else {
                 $resp_body = json_decode(json_encode($resp_body), FALSE);
                 if (isset($resp_body->status) && 'COMPLETED' === $resp_body->status) {
@@ -147,20 +147,29 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                         $get_order->save();
                         WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': vault token created');
                     } else {
-                        $txn_id = $resp_body->purchase_units[0]->payments->captures[0]->id;
+                        $txn_id = $resp_body->purchase_units[0]->payments->captures[0]->id ?? null;
                     }
-                    WFOCU_Core()->data->set('_transaction_id', $txn_id);
-                    add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
-                    add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
-                    $this->payal_order_id = $paypal_order_id;
-                    $data = WFOCU_Core()->process_offer->_handle_upsell_charge(true);
+                    if ($txn_id) {
+                        WFOCU_Core()->data->set('_transaction_id', $txn_id);
+                        add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
+                        add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
+                        $this->payal_order_id = $paypal_order_id;
+                        $resp_body_array = json_decode(json_encode($resp_body), true);
+                        if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
+                            WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $resp_body_array, $txn_id, WFOCU_Core()->data->get('current_offer'), 'angelleye_ppcp_cc');
+                        }
+                        $data = WFOCU_Core()->process_offer->_handle_upsell_charge(true);
+                    } else {
+                        $data = WFOCU_Core()->process_offer->_handle_upsell_charge(false);
+                        WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': CC capture completed but no transaction ID found');
+                    }
                 } elseif (isset($resp_body->details) && is_array($resp_body->details) && ( 'ORDER_ALREADY_CAPTURED' === $resp_body->details[0]->issue )) {
                     $get_offer = WFOCU_Core()->offers->get_the_next_offer();
                     $data = [];
                     $data['redirect_url'] = WFOCU_Core()->public->get_the_upsell_url($get_offer);
                 } else {
                     $data = WFOCU_Core()->process_offer->_handle_upsell_charge(false);
-                    WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to capture paypal Order refer error below' . print_r($resp_body, true));
+                    WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to process paypal CC Order refer error below' . print_r($resp_body, true));
                 }
             }
             wp_redirect($data['redirect_url']);
@@ -357,7 +366,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                     WFOCU_Core()->data->save();
                     $data = array();
                     $data['timeout'] = 30;
-                    $data['intent'] = $ppcp_data['intent'];
+                    $data['intent'] = 'CAPTURE';
                     $data['purchase_units'] = $this->get_purchase_units($get_order, $offer_package, $ppcp_data);
                     $data['application_context'] = array(
                         'user_action' => 'CONTINUE',
@@ -419,15 +428,18 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                             $order->save();
                         }
                         $this->payal_order_id = $ppcp_resp['id'];
-                        if ('COMPLETED' == $ppcp_resp['status']) {
+                        if (isset($ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'])) {
                             $get_order->update_meta_data('wfocu_ppcp_order_current', $ppcp_resp['id']);
                             $get_order->save();
-                            WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal Order successfully created');
+                            WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal CC Upsell Order captured');
                             $transaction_id = $ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'];
                             WFOCU_Core()->data->set('_transaction_id', $transaction_id);
                             if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
                                 WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $ppcp_resp, $transaction_id, $get_current_offer, 'angelleye_ppcp_cc');
                             }
+                            add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
+                            add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
+                            $this->payal_order_id = $ppcp_resp['id'];
                             $is_successful = true;
                         } else {
                             $is_successful = false;

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php
@@ -147,22 +147,17 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_CC extends WFOCU_Gateway {
                         $get_order->save();
                         WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': vault token created');
                     } else {
-                        $txn_id = $resp_body->purchase_units[0]->payments->captures[0]->id ?? null;
+                        $txn_id = $resp_body->purchase_units[0]->payments->captures[0]->id;
                     }
-                    if ($txn_id) {
-                        WFOCU_Core()->data->set('_transaction_id', $txn_id);
-                        add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
-                        add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
-                        $this->payal_order_id = $paypal_order_id;
-                        $resp_body_array = json_decode(json_encode($resp_body), true);
-                        if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
-                            WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $resp_body_array, $txn_id, WFOCU_Core()->data->get('current_offer'), 'angelleye_ppcp_cc');
-                        }
-                        $data = WFOCU_Core()->process_offer->_handle_upsell_charge(true);
-                    } else {
-                        $data = WFOCU_Core()->process_offer->_handle_upsell_charge(false);
-                        WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': CC capture completed but no transaction ID found');
+                    WFOCU_Core()->data->set('_transaction_id', $txn_id);
+                    add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
+                    add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
+                    $this->payal_order_id = $paypal_order_id;
+                    $resp_body_array = json_decode(json_encode($resp_body), true);
+                    if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
+                        WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $resp_body_array, $txn_id, WFOCU_Core()->data->get('current_offer'), 'angelleye_ppcp_cc');
                     }
+                    $data = WFOCU_Core()->process_offer->_handle_upsell_charge(true);
                 } elseif (isset($resp_body->details) && is_array($resp_body->details) && ( 'ORDER_ALREADY_CAPTURED' === $resp_body->details[0]->issue )) {
                     $get_offer = WFOCU_Core()->offers->get_the_next_offer();
                     $data = [];

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php
@@ -34,6 +34,8 @@ if (!class_exists('WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper')) {
                     'paypal_order_id' => isset($ppcp_resp['id']) ? $ppcp_resp['id'] : '',
                     'capture_id' => $transaction_id,
                     'transaction_id' => $transaction_id,
+                    'amount' => $ppcp_resp['purchase_units'][0]['amount']['value'] ?? '',
+                    'currency' => $ppcp_resp['purchase_units'][0]['amount']['currency_code'] ?? '',
                     'status' => isset($ppcp_resp['status']) ? $ppcp_resp['status'] : '',
                     'created_at' => time(),
                     'order_item_ids' => array(),
@@ -43,11 +45,12 @@ if (!class_exists('WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper')) {
                 $parent_order->save();
 
                 // Hook into wfocu_offer_accepted_and_processed (fires in both batching and non-batching modes)
-                // to capture the WC order item IDs added for this upsell and store them against the capture.
+                // to capture the WC order item IDs added for this upsell and store them against the payment entry.
+                // Match by paypal_order_id since capture_id/transaction_id can be NULL for authorize flow.
                 $parent_order_id = $parent_order->get_id();
-                $stored_transaction_id = $transaction_id;
-                add_action('wfocu_offer_accepted_and_processed', function($offer_id, $package, $porder, $new_order, $txn_id, $items_added) use ($parent_order_id, $stored_transaction_id) {
-                    if ($txn_id !== $stored_transaction_id) {
+                $stored_paypal_order_id = isset($ppcp_resp['id']) ? $ppcp_resp['id'] : '';
+                add_action('wfocu_offer_accepted_and_processed', function($offer_id, $package, $porder, $new_order, $txn_id, $items_added) use ($parent_order_id, $stored_paypal_order_id) {
+                    if (empty($stored_paypal_order_id)) {
                         return;
                     }
                     $parent_order = wc_get_order($parent_order_id);
@@ -59,7 +62,7 @@ if (!class_exists('WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper')) {
                         return;
                     }
                     foreach ($existing as &$entry) {
-                        if (isset($entry['capture_id']) && $entry['capture_id'] === $stored_transaction_id) {
+                        if (isset($entry['paypal_order_id']) && $entry['paypal_order_id'] === $stored_paypal_order_id) {
                             $entry['order_item_ids'] = is_array($items_added) ? $items_added : array();
                             break;
                         }

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -254,7 +254,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                 WFOCU_Core()->data->save();
                 $ppcp_data = $this->get_ppcp_meta();
                 $data = array(
-                    'intent' => 'CAPTURE',
+                    'intent' => $ppcp_data['intent'],
                     'application_context' => array(
                         'user_action' => 'PAY_NOW',
                         'landing_page' => $this->landing_page,

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -218,6 +218,10 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                     add_action('wfocu_db_event_row_created_' . WFOCU_DB_Track::OFFER_ACCEPTED_ACTION_ID, array($this, 'add_order_id_as_meta'));
                     add_action('wfocu_offer_new_order_created_' . $this->get_key(), array($this, 'add_paypal_meta_in_new_order'), 10, 2);
                     $this->payal_order_id = $paypal_order_id;
+                    $resp_body_array = json_decode(json_encode($resp_body), true);
+                    if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {
+                        WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::store_wfocu_batching_upsell_payment($get_order, $resp_body_array, $txn_id, WFOCU_Core()->data->get('current_offer'), 'angelleye_ppcp');
+                    }
                     $data = WFOCU_Core()->process_offer->_handle_upsell_charge(true);
                 } elseif (isset($resp_body->details) && is_array($resp_body->details) && ( 'ORDER_ALREADY_CAPTURED' === $resp_body->details[0]->issue )) {
                     $get_offer = WFOCU_Core()->offers->get_the_next_offer();
@@ -225,7 +229,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                     $data['redirect_url'] = WFOCU_Core()->public->get_the_upsell_url($get_offer);
                 } else {
                     $data = WFOCU_Core()->process_offer->_handle_upsell_charge(false);
-                    WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to capture paypal Order refer error below' . print_r($resp_body, true));
+                    WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': Unable to process paypal Order refer error below' . print_r($resp_body, true));
                 }
             }
             wp_redirect($data['redirect_url']);
@@ -422,7 +426,7 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                     WFOCU_Core()->data->save();
                     $data = array();
                     $data['timeout'] = 30;
-                    $data['intent'] = $ppcp_data['intent'];
+                    $data['intent'] = 'CAPTURE';
                     $data['purchase_units'] = $this->get_purchase_units($get_order, $offer_package, $ppcp_data);
                     $data['application_context'] = array(
                         'user_action' => 'CONTINUE',
@@ -484,10 +488,11 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                             $order->save();
                         }
                         $this->payal_order_id = $ppcp_resp['id'];
-                        if ('COMPLETED' == $ppcp_resp['status']) {
+                        if (isset($ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'])) {
+                            // Captured successfully
                             $get_order->update_meta_data('wfocu_ppcp_order_current', $ppcp_resp['id']);
                             $get_order->save();
-                            WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal Order successfully created');
+                            WFOCU_Core()->log->log('Order #' . WFOCU_WC_Compatibility::get_order_id($get_order) . ': PayPal Upsell Order captured');
                             $transaction_id = $ppcp_resp['purchase_units'][0]['payments']['captures'][0]['id'];
                             WFOCU_Core()->data->set('_transaction_id', $transaction_id);
                             if (WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP_Helper::is_wfocu_batching_mode()) {


### PR DESCRIPTION
#### Problem

When PFW is in **Authorization** mode with FunnelKit **order merge (batching)** enabled:

1. Customer checks out → parent PayPal order **authorized** for $100
2. Customer accepts upsell → FunnelKit creates a **separate** PayPal order, captures $50 immediately
3. FunnelKit merges upsell items into the parent WC order → order total is now $150
4. Admin captures the parent authorization → tries $150 against the $100 authorization

Error: MAX_CAPTURE_AMOUNT_EXCEEDED
Capture amount exceeds allowable limit (115% of order amount).

#### Root Cause

Two issues:

1. **No upsell awareness in admin capture** — `angelleye_ppcp_capture_authorized_payment_admin()` read `$order->get_total()` (which includes merged upsell items) and tried to capture the full amount against the parent authorization that was only for the original checkout amount.

2. **`order_item_ids` always empty in upsell meta** — The helper's `wfocu_offer_accepted_and_processed` hook matched entries by `capture_id`, but this field could be NULL. The match failed silently → `order_item_ids` stayed `[]` → the capture logic couldn't identify which items belonged to upsells.

#### Solution

**Force CAPTURE intent for all FunnelKit upsells** (both PPCP and CC gateways) — since upsells are separate PayPal orders, there's no reason to authorize them. Then subtract already-captured upsell amounts from the parent authorization capture.

#### Changes

##### `ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php`
- `process_client_order()` — hardcode `CAPTURE` intent (unchanged from original)
- `process_charge()` — hardcode `CAPTURE` intent (was `$ppcp_data['intent']` which sent AUTHORIZE when parent was authorize mode, but the response handler never supported authorization responses)
- `handle_api_calls()` — always call `/capture` endpoint, store upsell data via `store_wfocu_batching_upsell_payment()` in batching mode

##### `ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-cc.php`
- Same changes mirrored for the CC gateway
- Added batching storage in `handle_api_calls()` (was missing)
- Added null-safe capture ID extraction

##### `ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp-helper.php`
- `store_wfocu_batching_upsell_payment()` — store `amount` and `currency` from PayPal response for parent capture subtraction
- Fix `order_item_ids` population: match by `paypal_order_id` instead of `capture_id` (which was NULL for some flows)

##### `ppcp-gateway/class-angelleye-paypal-ppcp-payment.php`
- `angelleye_ppcp_capture_authorized_payment_admin()` — before capturing, read `_angelleye_wfocu_ppcp_upsell_payments` meta and exclude upsell amounts from parent capture:
  - If `order_item_ids` present → remove those items from `refund_line_total`
  - If `order_item_ids` empty → subtract stored `amount` from capture total
  - If remaining amount ≤ 0 → skip parent capture entirely with order note

#### Flow

Checkout (Authorization mode)
→ Parent order AUTHORIZED for $100
→ auth ID stored as _auth_transaction_id, order goes on-hold

FunnelKit Upsell (batching mode)
→ Separate PayPal order with CAPTURE intent
→ $50 captured immediately
→ Stored in _angelleye_wfocu_ppcp_upsell_payments:
{ capture_id, paypal_order_id, amount: "50.00", currency: "USD", order_item_ids: [...] }

Admin Capture (manual or auto on status change)
→ Reads _angelleye_wfocu_ppcp_upsell_payments
→ Removes upsell items from refund_line_total (or subtracts amount as fallback)
→ Captures remaining $100 against parent _auth_transaction_id
→ No MAX_CAPTURE_AMOUNT_EXCEEDED ✓


#### Testing

- [ ] **Auth mode + batching + checkout page:** Place order → accept upsell → verify upsell captured immediately → admin capture parent → correct amount, no error
- [ ] **Auto-capture on status change:** Change order to Processing → parent auth captured for parent-only amount
- [ ] **Multiple upsells:** Accept 2+ upsells → all captured → parent capture subtracts all upsell amounts
- [ ] **Empty order_item_ids fallback:** Verify stored `amount` is subtracted when `order_item_ids` is empty
- [ ] **Capture mode (non-auth):** No regression — upsells work normally when Payment Action = Capture
- [ ] **CC gateway:** Same tests with PPCP CC payment method
- [ ] **Refunds:** Refund parent items → correct capture ID. Refund upsell items → correct capture ID
- [ ] **All upsell items only capture:** If admin tries to capture only upsell items → skipped with note, no API error

