### PR TITLE
Fix: Load parent gateway classes before subscription subclasses to pr…

### DIFF
--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -573,6 +573,17 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             // Ensure PPCP traits/classes are loaded before any direct gateway class includes.
             $this->bootstrap_ppcp_runtime();
 
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-payflow-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-advanced-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-braintree-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php');
+            if (is_angelleye_multi_account_active()) {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v1.php');
+            } else {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v2.php');
+            }
+
             if (class_exists('WC_Subscriptions') && function_exists('wcs_create_renewal_order')) {
                 $this->subscription_support_enabled = true;
             }


### PR DESCRIPTION
**Problem**
AngellEYE v4.6.9 triggers a fatal error (Class "WC_Gateway_PayPal_Pro_PayFlow_AngellEYE" not found) when any other plugin calls WC()->payment_gateways during the init hook, before the parent gateway classes have been loaded by AngellEYE_Gateway_Paypal::init().
The subscription subclass files (e.g., wc-gateway-paypal-pro-payflow-subscriptions-angelleye.php) are included in angelleye_add_paypal_pro_gateway() via the woocommerce_payment_gateways filter, but the parent classes they extend are only loaded later in the init() method. When gateway loading is triggered early, the parent classes don't exist yet and PHP throws a fatal error.
Known triggers include YayMail Conditional Logic, WooCommerce Gateway PayPal Powered by Braintree, Payment Gateways Per Product & Category (Alg_WC_PGPP), and CartFlows — but any plugin calling WC()->payment_gateways during init will cause the same crash.

**Fix**
Add include_once calls for all parent gateway classes at the top of angelleye_add_paypal_pro_gateway(), immediately after $this->bootstrap_ppcp_runtime(). Since include_once is idempotent, there is no impact when the classes are loaded again later through the normal init() path.
Files changed
paypal-for-woocommerce.php — angelleye_add_paypal_pro_gateway() method

**Tested on**

WordPress 6.7.2 / PHP 8.1 / WooCommerce 9.x / Nexcess hosting with Object Cache Pro
WordPress 6.9.4 / PHP 8.3.30 / WooCommerce 9.x
Confirmed fix resolves fatal error across multiple client environments with different early-loading triggers