### PR TITLE
Add Local Pickup support to skip shipping address in PayPal orders

### DIFF
--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -1,4 +1,52 @@
 <?php
+if (!function_exists('angelleye_ppcp_is_local_pickup_chosen')) {
+
+    /**
+     * Detect whether the customer has chosen WooCommerce Local Pickup as the
+     * shipping method. When pickup is chosen, the PayPal order must use
+     * shipping_preference = NO_SHIPPING and omit purchase_units[].shipping
+     * to avoid binding the seller to free shipping under PayPal Seller
+     * Protection rules.
+     *
+     * @param WC_Order|null $order Optional WC order. When provided, reads
+     *                             the order's shipping items. Otherwise reads
+     *                             the WC session's chosen_shipping_methods.
+     * @return bool True only when ALL chosen shipping methods are local_pickup.
+     */
+    function angelleye_ppcp_is_local_pickup_chosen($order = null) {
+        // Order context (pay_page / capture / authorize)
+        if ($order instanceof WC_Order) {
+            $shipping_items = $order->get_shipping_methods();
+            if (empty($shipping_items)) {
+                return false;
+            }
+            foreach ($shipping_items as $item) {
+                $method_id = $item->get_method_id();
+                if ($method_id !== 'local_pickup') {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Session context (cart / checkout / product / FKCart)
+        if (!function_exists('WC') || !WC()->session) {
+            return false;
+        }
+        $chosen = WC()->session->get('chosen_shipping_methods');
+        if (empty($chosen) || !is_array($chosen)) {
+            return false;
+        }
+        foreach ($chosen as $rate_id) {
+            // Rate IDs look like "local_pickup:3"; method ID is the prefix
+            if (strpos((string) $rate_id, 'local_pickup') !== 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
 if (!function_exists('angelleye_ppcp_remove_empty_key')) {
 
     function angelleye_ppcp_remove_empty_key($data) {

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -344,7 +344,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                     $shipping_country = $order->get_billing_country();
                 }
                 $shipping_country = strtoupper($shipping_country);
-                if ($order->needs_shipping_address() || WC()->cart->needs_shipping()) {
+                if (($order->needs_shipping_address() || WC()->cart->needs_shipping()) && !angelleye_ppcp_is_local_pickup_chosen($order)) {
                     if (!empty($shipping_first_name) && !empty($shipping_last_name)) {
                         $body_request['purchase_units'][0]['shipping']['name']['full_name'] = $shipping_first_name . ' ' . $shipping_last_name;
                     }
@@ -364,7 +364,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                     }
                 }
             } else {
-                if (true === WC()->cart->needs_shipping()) {
+                if (true === WC()->cart->needs_shipping() && !angelleye_ppcp_is_local_pickup_chosen()) {
                     if (!empty($cart['shipping_address']['first_name']) && !empty($cart['shipping_address']['last_name'])) {
                         $body_request['purchase_units'][0]['shipping']['name']['full_name'] = $cart['shipping_address']['first_name'] . ' ' . $cart['shipping_address']['last_name'];
                     }
@@ -382,7 +382,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                 }
             }
             if ($this->angelleye_ppcp_used_payment_method === 'venmo') {
-                if (is_user_logged_in()) {
+                if (is_user_logged_in() && !angelleye_ppcp_is_local_pickup_chosen()) {
                     if (!empty($cart['shipping_address']['first_name']) && !empty($cart['shipping_address']['last_name'])) {
                         $body_request['purchase_units'][0]['shipping']['name']['full_name'] = $cart['shipping_address']['first_name'] . '' . $cart['shipping_address']['last_name'];
                     }
@@ -468,10 +468,10 @@ class AngellEYE_PayPal_PPCP_Payment {
         if (!empty($order)) {
             $details = $this->getOrderLineItems($order);
             $totalAmount = $order->get_total('');
-            $shippingRequired = $order->needs_shipping_address();
+            $shippingRequired = $order->needs_shipping_address() && !angelleye_ppcp_is_local_pickup_chosen($order);
         } elseif (isset(WC()->cart)) {
             $totalAmount = WC()->cart->get_total('');
-            $shippingRequired = WC()->cart->needs_shipping();
+            $shippingRequired = WC()->cart->needs_shipping() && !angelleye_ppcp_is_local_pickup_chosen();
             $details = $this->getCartLineItems();
         }
         return [
@@ -897,6 +897,12 @@ class AngellEYE_PayPal_PPCP_Payment {
     }
 
     public function angelleye_ppcp_shipping_preference() {
+        // Local Pickup short-circuits to NO_SHIPPING on every entry point.
+        // Avoids passing a shipping address that would bind the seller to free
+        // shipping under PayPal Seller Protection.
+        if (angelleye_ppcp_is_local_pickup_chosen()) {
+            return 'NO_SHIPPING';
+        }
         $shipping_preference = 'GET_FROM_FILE';
         $page = null;
         if (isset($_GET) && !empty($_GET['from'])) {
@@ -1625,7 +1631,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                 $shipping_country = $order->get_billing_country();
             }
             $shipping_country = strtoupper($shipping_country);
-            if ($order->needs_shipping_address() || WC()->cart->needs_shipping()) {
+            if (($order->needs_shipping_address() || WC()->cart->needs_shipping()) && !angelleye_ppcp_is_local_pickup_chosen($order)) {
                 if (!empty($shipping_first_name) && !empty($shipping_last_name)) {
                     $purchase_units['shipping']['name']['full_name'] = $shipping_first_name . ' ' . $shipping_last_name;
                 }
@@ -2490,7 +2496,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                     $shipping_country = $order->get_billing_country();
                 }
                 $shipping_country = strtoupper($shipping_country);
-                if ($order->needs_shipping_address() || WC()->cart->needs_shipping()) {
+                if (($order->needs_shipping_address() || WC()->cart->needs_shipping()) && !angelleye_ppcp_is_local_pickup_chosen($order)) {
                     if (!empty($shipping_first_name) && !empty($shipping_last_name)) {
                         $body_request['purchase_units'][0]['shipping']['name']['full_name'] = $shipping_first_name . ' ' . $shipping_last_name;
                     }
@@ -2505,7 +2511,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                     );
                 }
             } else {
-                if (true === WC()->cart->needs_shipping()) {
+                if (true === WC()->cart->needs_shipping() && !angelleye_ppcp_is_local_pickup_chosen()) {
                     if (is_user_logged_in()) {
                         if (!empty($cart['shipping_address']['first_name']) && !empty($cart['shipping_address']['last_name'])) {
                             $body_request['purchase_units'][0]['shipping']['name']['full_name'] = $cart['shipping_address']['first_name'] . ' ' . $cart['shipping_address']['last_name'];
@@ -3326,7 +3332,7 @@ class AngellEYE_PayPal_PPCP_Payment {
                     }
                 }
             }
-            if ($order->needs_shipping_address()) {
+            if ($order->needs_shipping_address() && !angelleye_ppcp_is_local_pickup_chosen($order)) {
                 if ($order->has_shipping_address()) {
                     $shipping_first_name = $order->get_shipping_first_name();
                     $shipping_last_name = $order->get_shipping_last_name();


### PR DESCRIPTION
## Summary

When a customer selects WooCommerce's **Local Pickup** shipping method, PFW was still sending `purchase_units[0].shipping.address` in the PayPal create_order request and using `GET_FROM_FILE` / `SET_PROVIDED_ADDRESS` for `shipping_preference`. PayPal's Orders v2 API treats this as a shippable transaction — under Seller Protection rules, the seller is then bound to fulfill the order to that address for free, even though the buyer chose to pick it up in store.

This PR detects Local Pickup from `WC()->session->get('chosen_shipping_methods')` (or `$order->get_shipping_methods()` on the order-pay page) and routes the request to `shipping_preference=NO_SHIPPING` with no shipping address attached.

## Changes

### New helper

- `angelleye_ppcp_is_local_pickup_chosen($order = null)` in `ppcp-gateway/angelleye-paypal-ppcp-common-functions.php`
  - Order context (pay_page / capture / authorize): reads `$order->get_shipping_methods()` and returns true only when **every** shipping item has `method_id === 'local_pickup'`.
  - Session context (cart / checkout / product / FunnelKit Cart): reads `WC()->session->get('chosen_shipping_methods')` and returns true only when **every** chosen rate ID starts with `local_pickup` (handles both `local_pickup` and instance-based `local_pickup:N` rate IDs).
  - Mixed packages (one shippable + one pickup) intentionally return `false` — those still need an address.

### `class-angelleye-paypal-ppcp-payment.php`

- **`angelleye_ppcp_shipping_preference()`** — short-circuits to `NO_SHIPPING` when local pickup is chosen. Single change covers `application_context.shipping_preference` and Venmo's `experience_context.shipping_preference`.
- **`angelleye_ppcp_create_order_request()`** — guarded all three shipping address blocks (pay_page order context, cart guest context, and the Venmo logged-in fallback).
- **`angelleye_ppcp_regular_create_order_request()`** — same guards on its two shipping blocks (used in `checkout_disable_smart_button` mode).
- **`angelleye_ppcp_capture_order_using_payment_method_token()`** — guarded the order-context shipping block (saved-token capture flow).
- **`angelleye_ppcp_update_order()`** — guarded the PATCH-time shipping block so capture/auth requests don't re-add the address after a clean create_order.
- **`ae_get_updated_checkout_payment_data()`** — `shippingRequired` flag now reflects Local Pickup so Apple Pay / Google Pay payment sheets skip the address picker too.

## What we're not doing (and why)

- **Patching `application_context.shipping_preference` after order creation** — PayPal's Orders v2 API does not allow this field to be patched. If a buyer creates a PayPal order while shipping is required, then changes to Local Pickup before clicking Place Order, we strip the address at PATCH time but PayPal will still have shown the address picker in the popup. Acceptable trade-off; the much more common case (Local Pickup chosen *before* clicking PayPal) is fully covered.
- **Touching `_setup_tokens` / `_billing_agreement` flows** — those use `GET_FROM_FILE` with no purchase shipping address by design and are already safe.

## Test plan

Pre-req: WooCommerce → Settings → Shipping → add a zone with both **Local Pickup** and **Flat Rate** methods.

- [ ] **Cart page, pickup chosen** — add product, go to /cart, select Local Pickup, click PayPal smart button. Verify the create_order request shows `shipping_preference=NO_SHIPPING` and no `purchase_units[0].shipping`. PayPal popup should not show an address picker.
- [ ] **Checkout page, pickup chosen** — fill billing, select Local Pickup in shipping methods, click PayPal smart button (top of page). Same expectations.
- [ ] **ACDC card form, pickup chosen** — same as above using the Advanced Card Fields form.
- [ ] **Switch shipping → pickup mid-checkout** — start with Flat Rate, click PayPal (popup shows address picker as expected), cancel, switch to Local Pickup, click PayPal again → new create_order fires with `NO_SHIPPING`.
- [ ] **Order-pay page** — create a manual order with Local Pickup, status `pending`. Open the pay link → click PayPal → expect `NO_SHIPPING`. Place order → capture/auth PATCH should not re-add a shipping block.
- [ ] **Apple Pay sheet, pickup chosen** — sheet should not request a shipping address.
- [ ] **Regression: standard shippable order** — Flat Rate selected → `SET_PROVIDED_ADDRESS` on checkout, `GET_FROM_FILE` on cart, address populated as before.
- [ ] **Regression: digital-only cart** — `WC()->cart->needs_shipping()===false` → `NO_SHIPPING` (existing behavior unchanged).
- [ ] **Regression: mixed packages** (one shippable + one pickup, multi-package setup) → falls back to standard shipping flow.

## Files changed

- `paypal-for-woocommerce/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php`
- `paypal-for-woocommerce/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php`
