### PR TITLE
Fix PPCP / PPCP-CC on WooCommerce Blocks checkout

### DIFF
--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -806,6 +806,27 @@ if (!function_exists('angelleye_ppcp_is_cart_subscription')) {
 
 }
 
+if (!function_exists('angelleye_ppcp_is_store_api_request')) {
+
+    /**
+     * Detect whether the current request is being served by the WooCommerce
+     * Store API (Blocks checkout). Used to guard exit()/false returns that
+     * are incompatible with the REST request lifecycle while keeping the
+     * classic-checkout behavior byte-identical.
+     */
+    function angelleye_ppcp_is_store_api_request() {
+        if (defined('REST_REQUEST') && REST_REQUEST) {
+            return true;
+        }
+        if (!empty($_SERVER['REQUEST_URI'])
+            && false !== strpos((string) $_SERVER['REQUEST_URI'], '/wc/store/')) {
+            return true;
+        }
+        return false;
+    }
+
+}
+
 if (!function_exists('angelleye_ppcp_is_save_payment_method')) {
 
     function angelleye_ppcp_is_save_payment_method($enable_tokenized_payments) {

--- a/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
+++ b/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
@@ -29,7 +29,11 @@ final class AngellEYE_PPCP_CC_Block extends AbstractPaymentMethodType {
         if (angelleye_ppcp_has_active_session()) {
             $order_button_text = apply_filters('angelleye_ppcp_cc_order_review_page_place_order_button_text', __('Confirm Your PayPal Order', 'paypal-for-woocommerce'));
         } else {
-            $order_button_text = 'Proceed to PayPal';
+            // PPCP-CC renders hosted card fields inline — the customer enters
+            // the card here and the capture happens in-flow, so this button
+            // should read "Place order" (Blocks default), not "Proceed to
+            // PayPal" (which belongs to the redirect-based smart button).
+            $order_button_text = apply_filters('angelleye_ppcp_cc_place_order_button_text', __('Place order', 'paypal-for-woocommerce'));
         }
         $is_paylater_enable_incart_page = 'no';
         if ($this->pay_later->is_paypal_pay_later_messaging_enable_for_page($page = 'cart') && $this->pay_later->pay_later_messaging_cart_shortcode === false) {

--- a/ppcp-gateway/checkout-block/ppcp-cc.js
+++ b/ppcp-gateway/checkout-block/ppcp-cc.js
@@ -115,27 +115,136 @@ var {registerExpressPaymentMethod, registerPaymentMethod} = wc.wcBlocksRegistry;
                 const {useEffect} = window.wp.element;
 
                 const Content_PPCP_CC = (props) => {
-                    const {eventRegistration, emitResponse, onSubmit, billing, shippingData} = props;
+                    const {eventRegistration, emitResponse} = props;
                     const {onPaymentSetup} = eventRegistration;
                     useEffect(() => {
                         jQuery(document.body).trigger('trigger_angelleye_ppcp_cc');
-                        jQuery(document.body).on('ppcp_cc_checkout_updated', function () {
-                            let address = {
-                                'billing': billing.billingAddress,
-                                'shipping': shippingData.shippingAddress
-                            };
-                            angelleyeOrder.ppcp_address = [];
-                            angelleyeOrder.ppcp_address = address;
-                            jQuery('#wc-angelleye_ppcp_cc-form').unblock();
-                            angelleyeOrder.renderPaymentButtons();
-                        });
+                        // Schedule a reset of the Blocks payment store to idle on the
+                        // next macrotask. Called after any ERROR return so the user's
+                        // retry click reaches our subscriber again instead of being
+                        // short-circuited by Blocks' built-in "payment option" fallback.
+                        const schedulePaymentStateReset = () => {
+                            setTimeout(function () {
+                                try {
+                                    var paymentStoreKey = wc && wc.wcBlocksData && wc.wcBlocksData.PAYMENT_STORE_KEY;
+                                    if (!paymentStoreKey) {
+                                        return;
+                                    }
+                                    var paymentDispatch = wp.data.dispatch(paymentStoreKey);
+                                    if (paymentDispatch && typeof paymentDispatch.__internalSetPaymentIdle === 'function') {
+                                        paymentDispatch.__internalSetPaymentIdle();
+                                    }
+                                } catch (e) {
+                                    // no-op — store shape may change across WC versions
+                                }
+                            }, 0);
+                        };
+                        // Scroll the user to the top-of-form notice area once Blocks has
+                        // had a tick to render the error notice DOM. Used for errors
+                        // returned at CHECKOUT context so the message is visible on
+                        // long checkout pages.
+                        const scrollToCheckoutNotice = () => {
+                            setTimeout(function () {
+                                try {
+                                    var target = document.querySelector('.wc-block-components-notices')
+                                        || document.querySelector('.wp-block-woocommerce-checkout')
+                                        || document.querySelector('form.wc-block-checkout__form');
+                                    if (target && typeof target.scrollIntoView === 'function') {
+                                        target.scrollIntoView({behavior: 'smooth', block: 'start'});
+                                    }
+                                } catch (e) {
+                                    // no-op
+                                }
+                            }, 80);
+                        };
                         const unsubscribe = onPaymentSetup(async () => {
-                            wp.data.dispatch(wc.wcBlocksData.CHECKOUT_STORE_KEY).__internalSetIdle();
-                            jQuery(document.body).trigger('submit_paypal_cc_form');
-                            jQuery('.wc-block-components-checkout-place-order-button').append('<span class="wc-block-components-spinner" aria-hidden="true"></span>');
-                            jQuery('.wc-block-components-checkout-place-order-button, .wp-block-woocommerce-checkout-fields-block #contact-fields, .wp-block-woocommerce-checkout-fields-block #billing-fields, .wp-block-woocommerce-checkout-fields-block #payment-method').block({message: null, overlayCSS: {background: '#fff', opacity: 0.6}});
+                            try {
+                                // If Blocks has any unresolved validation errors (e.g. a
+                                // required billing/shipping field is empty), defer to its
+                                // own field-level error display. Running card validation
+                                // now would show "credit card details are not valid" on
+                                // top of the real issue. Blocks will have already rendered
+                                // inline errors next to the offending fields, so we just
+                                // return a short pointer and skip the PayPal pre-flight.
+                                try {
+                                    var validationStoreKey = wc && wc.wcBlocksData && wc.wcBlocksData.VALIDATION_STORE_KEY;
+                                    if (validationStoreKey) {
+                                        var validationStore = wp.data.select(validationStoreKey);
+                                        if (validationStore && typeof validationStore.hasValidationErrors === 'function' && validationStore.hasValidationErrors()) {
+                                            schedulePaymentStateReset();
+                                            scrollToCheckoutNotice();
+                                            return {
+                                                type: emitResponse.responseTypes.ERROR,
+                                                message: 'Please complete all required fields before continuing.',
+                                                messageContext: emitResponse.noticeContexts.CHECKOUT,
+                                            };
+                                        }
+                                    }
+                                } catch (validationCheckErr) {
+                                    // Validation store shape may vary; fall through to
+                                    // the card-fields flow if we can't read it.
+                                }
+                                // Read LIVE address state at click time from the Blocks data
+                                // store instead of a stale useEffect closure. The cart store
+                                // holds customer data; the checkout store holds the
+                                // "Use same address for billing" checkbox.
+                                const cartStore = wp.data.select(wc.wcBlocksData.CART_STORE_KEY);
+                                const checkoutStore = wp.data.select(wc.wcBlocksData.CHECKOUT_STORE_KEY);
+                                const customerData = (cartStore && cartStore.getCustomerData && cartStore.getCustomerData()) || {};
+                                const useShippingAsBilling = (checkoutStore && typeof checkoutStore.getUseShippingAsBilling === 'function')
+                                    ? checkoutStore.getUseShippingAsBilling()
+                                    : false;
+                                let billingAddress = customerData.billingAddress || {};
+                                const shippingAddress = customerData.shippingAddress || {};
+                                if (useShippingAsBilling) {
+                                    billingAddress = Object.assign({}, shippingAddress, {
+                                        email: billingAddress.email || customerData.email || '',
+                                        phone: billingAddress.phone || shippingAddress.phone || '',
+                                    });
+                                }
+                                angelleyeOrder.ppcp_address = {
+                                    billing: billingAddress,
+                                    shipping: shippingAddress,
+                                };
+                                const paypalOrderId = await angelleyeOrder.runBlocksPpcpCcFlow();
+                                return {
+                                    type: emitResponse.responseTypes.SUCCESS,
+                                    meta: {
+                                        paymentMethodData: {
+                                            paypal_order_id: paypalOrderId,
+                                        },
+                                    },
+                                };
+                            } catch (err) {
+                                // Returning ERROR puts Blocks into a "hasPaymentError"
+                                // state that would otherwise short-circuit the next click
+                                // before our subscriber runs. Reset to idle so the retry
+                                // reaches us cleanly.
+                                schedulePaymentStateReset();
+                                // Card-field invalidity should be shown next to the
+                                // payment method block (where the card fields live).
+                                // All other failures (API errors, capture failures,
+                                // 3DS errors) go to the top-of-form notice area where
+                                // standard WC notices appear.
+                                const isCardInvalid = err && err.context === 'card_invalid';
+                                if (!isCardInvalid) {
+                                    scrollToCheckoutNotice();
+                                }
+                                return {
+                                    type: emitResponse.responseTypes.ERROR,
+                                    message: (err && err.message) || 'Unable to process PayPal card payment. Please try again.',
+                                    messageContext: isCardInvalid
+                                        ? emitResponse.noticeContexts.PAYMENTS
+                                        : emitResponse.noticeContexts.CHECKOUT,
+                                };
+                            }
                         });
-                    }, [onPaymentSetup]);
+                        return () => {
+                            if (typeof unsubscribe === 'function') {
+                                unsubscribe();
+                            }
+                        };
+                    }, [onPaymentSetup, emitResponse.responseTypes]);
                     return createElement(
                             "fieldset",
                             {id: "wc-angelleye_ppcp_cc-form", className: "wc-credit-card-form wc-payment-form"},

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
@@ -176,10 +176,62 @@ class AngellEYE_PayPal_PPCP_Front_Action {
                         $checkout_source = isset($_REQUEST['angelleye_ppcp_checkout_source']) ? wc_clean(wp_unslash($_REQUEST['angelleye_ppcp_checkout_source'])) : '';
                         $is_checkout_top = 'checkout_top' === $checkout_source;
                         $is_checkout_regular = 'checkout_regular' === $checkout_source;
+                        $is_block_checkout = 'block_checkout' === $checkout_source;
 
-                        if (!$is_checkout_top && !$is_checkout_regular) {
+                        if (!$is_checkout_top && !$is_checkout_regular && !$is_block_checkout) {
                             $is_checkout_top = empty($_POST);
                             $is_checkout_regular = !$is_checkout_top;
+                        }
+
+                        if ($is_block_checkout) {
+                            // WooCommerce Blocks checkout. This pre-flight call exists
+                            // only to build a PayPal order against the current cart so
+                            // the SDK has an order id to authorize against. All order
+                            // validation, custom fields, extensions and process_payment
+                            // routing happen later via the Store API /wc/store/v1/checkout
+                            // POST that Blocks fires after our SDK onApprove callback
+                            // returns the paypal_order_id via paymentMethodData.
+                            self::$is_user_logged_in_before_checkout = is_user_logged_in();
+                            if (isset($_POST['address']) && strlen($_POST['address']) > 2) {
+                                $address_data = json_decode(stripslashes($_POST['address']), true);
+                                if (is_array($address_data)) {
+                                    if (!empty($address_data['billing']) && is_array($address_data['billing'])) {
+                                        $b = $address_data['billing'];
+                                        !empty($b['first_name']) && $woocommerce->customer->set_billing_first_name($b['first_name']);
+                                        !empty($b['last_name']) && $woocommerce->customer->set_billing_last_name($b['last_name']);
+                                        !empty($b['company']) && $woocommerce->customer->set_billing_company($b['company']);
+                                        !empty($b['address_1']) && $woocommerce->customer->set_billing_address_1($b['address_1']);
+                                        !empty($b['address_2']) && $woocommerce->customer->set_billing_address_2($b['address_2']);
+                                        !empty($b['city']) && $woocommerce->customer->set_billing_city($b['city']);
+                                        !empty($b['state']) && $woocommerce->customer->set_billing_state($b['state']);
+                                        !empty($b['postcode']) && $woocommerce->customer->set_billing_postcode($b['postcode']);
+                                        !empty($b['country']) && $woocommerce->customer->set_billing_country($b['country']);
+                                        !empty($b['email']) && $woocommerce->customer->set_billing_email($b['email']);
+                                        !empty($b['phone']) && $woocommerce->customer->set_billing_phone($b['phone']);
+                                    }
+                                    if (!empty($address_data['shipping']) && is_array($address_data['shipping'])) {
+                                        $s = $address_data['shipping'];
+                                        !empty($s['first_name']) && $woocommerce->customer->set_shipping_first_name($s['first_name']);
+                                        !empty($s['last_name']) && $woocommerce->customer->set_shipping_last_name($s['last_name']);
+                                        !empty($s['company']) && $woocommerce->customer->set_shipping_company($s['company']);
+                                        !empty($s['address_1']) && $woocommerce->customer->set_shipping_address_1($s['address_1']);
+                                        !empty($s['address_2']) && $woocommerce->customer->set_shipping_address_2($s['address_2']);
+                                        !empty($s['city']) && $woocommerce->customer->set_shipping_city($s['city']);
+                                        !empty($s['state']) && $woocommerce->customer->set_shipping_state($s['state']);
+                                        !empty($s['postcode']) && $woocommerce->customer->set_shipping_postcode($s['postcode']);
+                                        !empty($s['country']) && $woocommerce->customer->set_shipping_country($s['country']);
+                                    }
+                                    $woocommerce->customer->save();
+                                }
+                            }
+                            if (!empty($_POST['angelleye_ppcp_payment_method_title'])) {
+                                AngellEye_Session_Manager::set('payment_method_title', wc_clean(wp_unslash($_POST['angelleye_ppcp_payment_method_title'])));
+                            }
+                            if (!empty($_POST['payment_method'])) {
+                                AngellEye_Session_Manager::set('payment_method_id', wc_clean(wp_unslash($_POST['payment_method'])));
+                            }
+                            $this->payment_request->angelleye_ppcp_create_order_request();
+                            exit();
                         }
 
                         if ($is_checkout_regular) {

--- a/ppcp-gateway/class-wc-gateway-cc-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-cc-angelleye.php
@@ -181,11 +181,25 @@ class WC_Gateway_CC_AngellEYE extends WC_Payment_Gateway_CC {
                     );
                 }
             }
-            $angelleye_ppcp_paypal_order_id = AngellEye_Session_Manager::get('paypal_order_id');
+            $angelleye_ppcp_paypal_order_id = !empty($_POST['paypal_order_id'])
+                ? wc_clean(wp_unslash($_POST['paypal_order_id']))
+                : AngellEye_Session_Manager::get('paypal_order_id');
+            if (!empty($_POST['paypal_order_id']) && !empty($angelleye_ppcp_paypal_order_id)) {
+                // Blocks carries the PayPal order id through paymentMethodData rather
+                // than the WC session. Downstream capture/update calls still read the
+                // session value, so write it back here.
+                AngellEye_Session_Manager::set('paypal_order_id', $angelleye_ppcp_paypal_order_id);
+            }
             $is_success = false;
             if (isset($_GET['from']) && 'checkout' === $_GET['from']) {
                 AngellEye_Session_Manager::set('checkout_post', isset($_POST) ? wc_clean($_POST) : false);
                 $this->payment_request->angelleye_ppcp_create_order_request($woo_order_id);
+                if (angelleye_ppcp_is_store_api_request()) {
+                    return array(
+                        'result'   => 'failure',
+                        'redirect' => '',
+                    );
+                }
                 exit();
             } elseif (!empty($angelleye_ppcp_paypal_order_id)) {
                 $order = wc_get_order($woo_order_id);
@@ -222,17 +236,37 @@ class WC_Gateway_CC_AngellEYE extends WC_Payment_Gateway_CC {
                 if (ob_get_length()) {
                     ob_end_clean();
                 }
+                if (!is_array($result)) {
+                    return array(
+                        'result'   => 'failure',
+                        'redirect' => wc_get_checkout_url(),
+                    );
+                }
                 return $result;
             } else {
                 $result = $this->payment_request->angelleye_ppcp_order_capture_request($woo_order_id);
                 if (ob_get_length()) {
                     ob_end_clean();
                 }
+                if (!is_array($result)) {
+                    return array(
+                        'result'   => 'failure',
+                        'redirect' => wc_get_checkout_url(),
+                    );
+                }
                 return $result;
             }
         } catch (Exception $ex) {
-            
+            if (isset($this->payment_request->api_log)) {
+                $this->payment_request->api_log->log("The exception was created on line: " . $ex->getFile() . ' ' . $ex->getLine(), 'error');
+                $this->payment_request->api_log->log($ex->getMessage(), 'error');
+            }
+            wc_add_notice($ex->getMessage(), 'error');
         }
+        return array(
+            'result'   => 'failure',
+            'redirect' => wc_get_checkout_url(),
+        );
     }
 
     public function is_available() {

--- a/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
@@ -392,7 +392,15 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
             }
             $this->paymentaction = apply_filters('angelleye_ppcp_paymentaction', $this->paymentaction, $woo_order_id);
             $order = wc_get_order($woo_order_id);
-            $angelleye_ppcp_paypal_order_id = AngellEye_Session_Manager::get('paypal_order_id');
+            $angelleye_ppcp_paypal_order_id = !empty($_POST['paypal_order_id'])
+                ? wc_clean(wp_unslash($_POST['paypal_order_id']))
+                : AngellEye_Session_Manager::get('paypal_order_id');
+            if (!empty($_POST['paypal_order_id']) && !empty($angelleye_ppcp_paypal_order_id)) {
+                // Blocks carries the PayPal order id through paymentMethodData rather
+                // than the WC session. Downstream capture/update calls still read the
+                // session value, so write it back here.
+                AngellEye_Session_Manager::set('paypal_order_id', $angelleye_ppcp_paypal_order_id);
+            }
             $angelleye_ppcp_payment_method_title = AngellEye_Session_Manager::get('payment_method_title');
             $angelleye_ppcp_used_payment_method = AngellEye_Session_Manager::get('used_payment_method');
             $order->update_meta_data('_angelleye_ppcp_used_payment_method', $angelleye_ppcp_used_payment_method);
@@ -437,11 +445,25 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
                 } elseif ( $redirect = $this->handle_overcharge_redirect( $is_success ) ) {
 	                return $redirect;
                 }
+                if (angelleye_ppcp_is_store_api_request()) {
+                    AngellEye_Session_Manager::clear();
+                    wc_add_notice(__('Unfortunately your payment could not be completed. Please try again.', 'paypal-for-woocommerce'), 'error');
+                    return array(
+                        'result'   => 'failure',
+                        'redirect' => wc_get_checkout_url(),
+                    );
+                }
                 exit();
             } else {
                 if (isset($_GET['from']) && 'checkout' === $_GET['from']) {
                     AngellEye_Session_Manager::set('checkout_post', isset($_POST) ? $_POST : false);
                     $this->payment_request->angelleye_ppcp_create_order_request($woo_order_id);
+                    if (angelleye_ppcp_is_store_api_request()) {
+                        return array(
+                            'result'   => 'failure',
+                            'redirect' => '',
+                        );
+                    }
                     exit();
                 } elseif (!empty($angelleye_ppcp_paypal_order_id)) {
                     $order = wc_get_order($woo_order_id);
@@ -485,18 +507,38 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
                     if (ob_get_length()) {
                         ob_end_clean();
                     }
+                    if (!is_array($result)) {
+                        return array(
+                            'result'   => 'failure',
+                            'redirect' => wc_get_checkout_url(),
+                        );
+                    }
                     return $result;
                 } else {
                     $result = $this->payment_request->angelleye_ppcp_regular_create_order_request($woo_order_id, $return_url = true);
                     if (ob_get_length()) {
                         ob_end_clean();
                     }
+                    if (!is_array($result)) {
+                        return array(
+                            'result'   => 'failure',
+                            'redirect' => wc_get_checkout_url(),
+                        );
+                    }
                     return $result;
                 }
             }
         } catch (Exception $ex) {
-
+            if (isset($this->payment_request->api_log)) {
+                $this->payment_request->api_log->log("The exception was created on line: " . $ex->getFile() . ' ' . $ex->getLine(), 'error');
+                $this->payment_request->api_log->log($ex->getMessage(), 'error');
+            }
+            wc_add_notice($ex->getMessage(), 'error');
         }
+        return array(
+            'result'   => 'failure',
+            'redirect' => wc_get_checkout_url(),
+        );
     }
 
 	protected function handle_overcharge_redirect( $is_success ) {

--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -155,6 +155,55 @@ const angelleyeOrder = {
             return data.orderID;
         });
     },
+    ppcp_block_mode: false,
+    blockCreateOrderError: null,
+    /**
+     * Drives the PPCP-CC card-fields submit pipeline for WooCommerce Blocks
+     * and returns a Promise that the Blocks onPaymentSetup subscriber awaits.
+     *   - Resolves with the PayPal order id when the SDK onApprove event
+     *     fires (after 3DS / card validation completes).
+     *   - Rejects with an Error when create_order / SDK / validation surface
+     *     a failure, so the Blocks subscriber returns ERROR and Blocks clears
+     *     the spinner and shows the message.
+     * After the promise resolves, the Blocks subscriber returns SUCCESS with
+     * the order id inside paymentMethodData; Blocks then POSTs the full
+     * Blocks checkout payload (including all custom fields and extensions)
+     * to /wc/store/v1/checkout, which routes through process_payment() for
+     * the actual capture.
+     */
+    runBlocksPpcpCcFlow: () => {
+        return new Promise((resolve, reject) => {
+            let settled = false;
+            angelleyeOrder.ppcp_block_mode = true;
+            angelleyeOrder.blockCreateOrderError = null;
+            const cleanup = () => {
+                jQuery(document.body).off('angelleye_ppcp_cc_approved.ppcpBlocks', approvalHandler);
+                jQuery(document.body).off('angelleye_ppcp_cc_error.ppcpBlocks', errorHandler);
+                angelleyeOrder.ppcp_block_mode = false;
+                angelleyeOrder.blockCreateOrderError = null;
+            };
+            const approvalHandler = (e, data) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                resolve(data && data.paypalOrderId);
+            };
+            const errorHandler = (e, errData) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                const err = new Error((errData && errData.message) || 'PayPal card payment failed');
+                // Preserve the failure context so the Blocks subscriber can
+                // decide where to display the notice (top of form vs inline
+                // next to the payment method).
+                err.context = (errData && errData.context) || null;
+                reject(err);
+            };
+            jQuery(document.body).on('angelleye_ppcp_cc_approved.ppcpBlocks', approvalHandler);
+            jQuery(document.body).on('angelleye_ppcp_cc_error.ppcpBlocks', errorHandler);
+            jQuery(document.body).trigger('submit_paypal_cc_form');
+        });
+    },
     createOrder: ({angelleye_ppcp_button_selector, billingDetails, shippingDetails, apiUrl, errorLogId, callback}) => {
         // Detect FunnelKit sliding cart buttons — they should always submit cart context, not product/page context.
         let fkcartSelectors = ['#angelleye_ppcp_fkcart', '#angelleye_ppcp_fkcart_apple_pay', '#angelleye_ppcp_fkcart_google_pay'];
@@ -194,10 +243,28 @@ const angelleyeOrder = {
         }
         let topCheckoutSelectors = ['#angelleye_ppcp_checkout_top', '#angelleye_ppcp_checkout_top_google_pay', '#angelleye_ppcp_checkout_top_apple_pay'];
         let checkoutSource = null;
-        if (is_from_checkout) {
+        let is_from_block_checkout = angelleyeOrder.ppcp_block_mode === true;
+        if (is_from_block_checkout) {
+            checkoutSource = 'block_checkout';
+        } else if (is_from_checkout) {
             checkoutSource = topCheckoutSelectors.indexOf(angelleye_ppcp_button_selector) > -1 ? 'checkout_top' : 'checkout_regular';
         }
-        if (is_from_checkout && topCheckoutSelectors.indexOf(angelleye_ppcp_button_selector) > -1) {
+        if (is_from_block_checkout) {
+            // WooCommerce Blocks pre-flight. Server only needs enough data
+            // to build a PayPal order against the cart (customer address so
+            // the PayPal order carries shipping/billing). All order-level
+            // validation, custom fields and extensions flow through the
+            // Store API /wc/store/v1/checkout POST that Blocks fires after
+            // the subscriber resolves.
+            let paymentMethodTitle = jQuery('#angelleye_ppcp_payment_method_title').val() || 'paypal';
+            formData = 'angelleye_ppcp_checkout_source=block_checkout';
+            formData += '&payment_method=angelleye_ppcp_cc';
+            formData += '&angelleye_ppcp_payment_method_title=' + encodeURIComponent(paymentMethodTitle);
+            formData += '&woocommerce-process-checkout-nonce=' + angelleye_ppcp_manager.woocommerce_process_checkout;
+            if (angelleyeOrder.ppcp_address !== null && angelleyeOrder.ppcp_address !== undefined && angelleyeOrder.ppcp_address !== '') {
+                formData += '&address=' + encodeURIComponent(JSON.stringify(angelleyeOrder.ppcp_address));
+            }
+        } else if (is_from_checkout && topCheckoutSelectors.indexOf(angelleye_ppcp_button_selector) > -1) {
             formData = 'angelleye_ppcp_checkout_source=' + encodeURIComponent(checkoutSource);
         } else if (is_from_fkcart) {
             // FunnelKit sliding cart — server reads existing WC()->cart contents, no form serialization needed
@@ -743,13 +810,30 @@ const angelleyeOrder = {
                         isItApiError = true;
                         // Reset hosted-card submit state so user can retry createOrder on next click.
                         jQuery(checkoutSelector).removeClass('processing paypal_cc_submiting createOrder');
-                        angelleyeOrder.showError(error);
+                        if (angelleyeOrder.ppcp_block_mode) {
+                            // Stash the server-side message so onError can surface it to the
+                            // Blocks subscriber instead of the generic SDK error.
+                            angelleyeOrder.blockCreateOrderError = (typeof error === 'string')
+                                ? error.replace(/<[^>]+>/g, '').trim()
+                                : (error && error.message) || 'PayPal card payment failed';
+                        } else {
+                            angelleyeOrder.showError(error);
+                        }
                         return '';
                     });
                 }
             },
             onApprove: function (data, actions) {
                 if (data.orderID) {
+                    if (angelleyeOrder.ppcp_block_mode) {
+                        // Blocks-native flow: hand the PayPal order id to the
+                        // runBlocksPpcpCcFlow promise. The Blocks subscriber will
+                        // then return SUCCESS with paymentMethodData, and the
+                        // Store API /wc/store/v1/checkout POST will carry the id
+                        // into process_payment() for capture.
+                        jQuery(document.body).trigger('angelleye_ppcp_cc_approved', [{paypalOrderId: data.orderID}]);
+                        return;
+                    }
                     angelleyeOrder.checkoutFormCapture({checkoutSelector, payPalOrderId: data.orderID, errorLogId});
                 }
             },
@@ -758,6 +842,12 @@ const angelleyeOrder = {
                 jQuery(checkoutSelector).removeClass('processing paypal_cc_submiting createOrder');
                 angelleyeOrder.stopPpcpCcSubmitWatchdog();
                 angelleyeOrder.hideProcessingSpinner(spinnerSelectors);
+                if (angelleyeOrder.ppcp_block_mode) {
+                    const blockMessage = angelleyeOrder.blockCreateOrderError
+                        || angelleyeOrder.parsePayPalSdkError(err);
+                    jQuery(document.body).trigger('angelleye_ppcp_cc_error', [{message: blockMessage}]);
+                    return;
+                }
                 if (!isItApiError) {
                     const errorMessage = angelleyeOrder.parsePayPalSdkError(err);
                     angelleyeOrder.showError(errorMessage);
@@ -801,6 +891,12 @@ const angelleyeOrder = {
             }
         });
         if (cardFields.isEligible()) {
+            // On Blocks checkout the form element gets replaced after a
+            // failed validation submit, so the `.CardFields` guard above
+            // doesn't prevent a re-entry. Wipe any stale iframes left over
+            // from the previous render before the SDK mounts new ones;
+            // otherwise the customer sees each card field duplicated.
+            jQuery('#angelleye_ppcp_cc-card-number, #angelleye_ppcp_cc-card-expiry, #angelleye_ppcp_cc-card-cvc').empty();
             cardFields.NumberField().render("#angelleye_ppcp_cc-card-number");
             cardFields.ExpiryField().render("#angelleye_ppcp_cc-card-expiry");
             cardFields.CVVField().render("#angelleye_ppcp_cc-card-cvc");
@@ -821,6 +917,17 @@ const angelleyeOrder = {
                     angelleyeOrder.stopPpcpCcSubmitWatchdog();
                     angelleyeOrder.hideProcessingSpinner();
                     jQuery(checkoutSelector).removeClass('processing paypal_cc_submiting CardFields createOrder');
+                    if (angelleyeOrder.ppcp_block_mode) {
+                        // context='card_invalid' signals the Blocks subscriber to
+                        // display this notice next to the payment method block
+                        // (where the card fields live) instead of at the top of
+                        // the checkout form.
+                        jQuery(document.body).trigger('angelleye_ppcp_cc_error', [{
+                            message: localizedMessages.fields_not_valid,
+                            context: 'card_invalid'
+                        }]);
+                        return;
+                    }
                     angelleyeOrder.removeError();
                     angelleyeOrder.showError(localizedMessages.fields_not_valid);
                     return;


### PR DESCRIPTION
## Summary

Restores PPCP and PPCP-CC on WooCommerce **Blocks checkout**. Before this PR the gateway could produce a PHP fatal, stuck spinners, empty address payloads, double-rendered card field iframes, stale payment-error state, and misplaced error notices. Classic checkout behavior is unchanged — every code path is gated on either `angelleye_ppcp_is_store_api_request()` (PHP) or `ppcp_block_mode` (JS).

## The bugs this fixes

1. **Fatal `array_merge()` TypeError.** `StoreApi\Legacy::process_legacy_payment` does `array_merge($result->payment_details, $gateway_result)`. PFW's `process_payment()` was returning bare `false` (from `angelleye_ppcp_order_capture_request()` hitting a missing `_paypal_order_id`) or implicit `null` (swallowed `catch (Exception)`). Classic checkout tolerated it via `exit()` redirects; Store API surfaces it as a fatal.
2. **Stale/empty address in the pre-flight POST.** The old Blocks subscriber captured `billing.billingAddress` and `shippingData.shippingAddress` through a `useEffect` closure bound at mount time, so the address JSON sent to wc-api was frozen to the initial empty React state.
3. **"Use same address for billing" invisible.** The Blocks checkbox state lives in `wc.wcBlocksData.CHECKOUT_STORE_KEY` and was never serialized anywhere, so billing fields stayed empty when that box was checked.
4. **Spinner never hid.** The old subscriber called `__internalSetIdle()`, appended a spinner, blocked the UI, and returned `undefined` — with no code path that cleaned any of it up.
5. **Race between wc-api and Store API.** The old flow fired `submit_paypal_cc_form` without awaiting it, letting Blocks POST `/wc/store/v1/checkout` in parallel with our legacy pipeline.
6. **Card fields rendered twice.** After a Blocks validation error the form element gets replaced; our `.CardFields` guard dropped with it, the SDK mounted new iframes over preserved React DOM, and the customer saw doubled inputs.
7. **"Proceed to PayPal" button label.** PPCP-CC renders card fields inline — the user isn't being redirected — so the button should read "Place order".
8. **Stuck `hasPaymentError` blocking retries.** After an error return, Blocks' payment store kept `hasPaymentError = true`, and a built-in validation subscriber short-circuited the next click with a generic `"There was a problem with your payment option."` notice before our subscriber could run. Users could not retry.
9. **Misplaced error notices.** All failures surfaced under the payment method block instead of the top of the checkout form where WC notices normally appear, with no scroll to reveal them.
10. **Card-invalid error shown when Blocks validation was already failing.** Users with empty required fields saw "credit card details are not valid" instead of letting Blocks' inline field errors lead.

## Architecture

```
[ user clicks Place Order ]
        │
        ▼
Blocks runs built-in validation → if errors, stops here
        │
        ▼
onPaymentSetup subscriber (ppcp-cc.js)
        │
        ├── Reads LIVE addresses + useShippingAsBilling from
        │   wc.wcBlocksData.CART_STORE_KEY / CHECKOUT_STORE_KEY
        │   (no stale closures)
        │
        ├── Copies shipping → billing when the checkbox is on
        │
        ├── runBlocksPpcpCcFlow() ─────────────────────────────────┐
        │                                                         │
        ▼                                                         │
wc-api/AngellEYE_PayPal_PPCP_Front_Action                         │
   ?angelleye_ppcp_action=create_order                            │
   &from=checkout                                                 │
   source=block_checkout                                          │
        │                                                         │
        ▼                                                         │
Server: is_block_checkout branch                                  │
   ├── Decodes address JSON into WC()->customer (no $_POST mutation)
   ├── Persists payment_method_title / _id to PFW session         │
   ├── angelleye_ppcp_create_order_request()   ← builds PayPal order
   └── exit() returns { orderID }                                 │
        │                                                         │
        ▼                                                         │
PayPal SDK cardFields.submit() → 3DS / card validation ───────────┘
        │
        ▼
onApprove(data.orderID) → trigger 'angelleye_ppcp_cc_approved'
        │
        ▼
runBlocksPpcpCcFlow promise resolves with paypalOrderId
        │
        ▼
Subscriber returns { SUCCESS, meta.paymentMethodData.paypal_order_id }
        │
        ▼
Blocks POSTs /wc/store/v1/checkout  ← full Blocks payload:
   billing_address, shipping_address, additional_fields,
   customer_note, create_account, customer_password,
   extensions.woocommerce/order-attribution, custom plugin fields,
   payment_method, payment_data: [{ key: "paypal_order_id", value }]
        │
        ▼
Store API creates WC order natively → process_legacy_payment →
process_payment() reads $_POST['paypal_order_id'] → writes to
session → routes into existing capture branch → capture → redirect
```

All Blocks-registered custom fields from third-party plugins (fields extended via `ExtendSchema::register_endpoint_data()`, order attribution, etc.) flow through the Store API POST naturally — no manual mapping.

## Changes

### Server

- **`angelleye-paypal-ppcp-common-functions.php`** — new `angelleye_ppcp_is_store_api_request()` helper. Returns true when `REST_REQUEST` is defined or the request URI contains `/wc/store/`. Every new server guard keys off this.
- **`class-angelleye-paypal-ppcp-front-action.php`** — new `block_checkout` branch in the `create_order` action. Decodes `$_POST['address']`, populates `WC()->customer` billing + shipping, persists `payment_method_title` / `payment_method_id` to the PFW session, and calls `angelleye_ppcp_create_order_request()`. **No `process_checkout()` call** — the draft WC order is created later via the Store API POST, and the pre-flight exists only to build a PayPal order id.
- **`class-wc-gateway-cc-angelleye.php`** — `process_payment()` now:
  - Reads `$_POST['paypal_order_id']` first, writes it back to session so `angelleye_ppcp_order_capture_request()` picks it up
  - Wraps `angelleye_ppcp_order_capture_request()` calls at both `checkout_disable_smart_button` branches, converting non-array returns into `['result' => 'failure', 'redirect' => wc_get_checkout_url()]`
  - Guards the `$_GET['from'] === 'checkout'` branch's `exit()` behind `angelleye_ppcp_is_store_api_request()` — classic flows still `exit()`, Store API flows return an array
  - Replaces the previously empty `catch (Exception)` with logging via `$this->payment_request->api_log` + `wc_add_notice()`
  - Adds a final fallthrough return of `['result' => 'failure', 'redirect' => wc_get_checkout_url()]` so no code path returns `null`
- **`class-wc-gateway-ppcp-angelleye.php`** — identical treatment for the smart-button gateway:
  - Session write-back of `$_POST['paypal_order_id']`
  - Normalized `angelleye_ppcp_regular_create_order_request()` returns
  - `exit()` guards on the token-capture fall-through (line 440) and the `from=checkout` branch (line 445)
  - Logging + notice + fallthrough in the catch block

### Frontend

- **`checkout-block/ppcp-cc.js`** — rewrote the `Content_PPCP_CC` subscriber:
  - Early `hasValidationErrors()` check against `wc.wcBlocksData.VALIDATION_STORE_KEY` — if Blocks has unresolved field errors, returns a short "Please complete all required fields before continuing." notice and skips the PayPal pre-flight entirely
  - Reads live customer data via `wc.wcBlocksData.CART_STORE_KEY.getCustomerData()` at click time
  - Honors `wc.wcBlocksData.CHECKOUT_STORE_KEY.getUseShippingAsBilling()` by copying shipping → billing client-side, preserving `email` / `phone` from billing when set
  - Awaits `angelleyeOrder.runBlocksPpcpCcFlow()` for the full SDK → onApprove cycle
  - Returns `{ type: SUCCESS, meta: { paymentMethodData: { paypal_order_id } } }` on success
  - On error: routes `err.context === 'card_invalid'` errors to `noticeContexts.PAYMENTS` (inline next to the card form), everything else to `noticeContexts.CHECKOUT` (top-of-form)
  - Helpers:
    - `schedulePaymentStateReset()` — dispatches `__internalSetPaymentIdle` on `wc.wcBlocksData.PAYMENT_STORE_KEY` via `setTimeout(0)` so the stale `hasPaymentError` doesn't block the retry click
    - `scrollToCheckoutNotice()` — `scrollIntoView` on `.wc-block-components-notices` (with sensible fallbacks) after an 80ms tick so the user sees top-of-form errors on long pages
  - `useEffect` cleanup unsubscribes from `onPaymentSetup` on unmount, preventing subscription leaks across re-renders
- **`js/wc-angelleye-common-functions.js`**:
  - New `runBlocksPpcpCcFlow()` — returns a Promise that sets `ppcp_block_mode = true`, listens for `angelleye_ppcp_cc_approved` / `angelleye_ppcp_cc_error` on `document.body` (namespace `.ppcpBlocks`), then triggers `submit_paypal_cc_form`. Resolves with the PayPal order id on approval; rejects with a context-tagged `Error` on failure. Cleanup always runs and resets `ppcp_block_mode = false`
  - `createOrder()` in block mode builds a minimal `block_checkout` payload:
    ```
    angelleye_ppcp_checkout_source=block_checkout
    payment_method=angelleye_ppcp_cc
    angelleye_ppcp_payment_method_title=<title>
    woocommerce-process-checkout-nonce=<nonce>
    address=<live JSON>
    ```
    No more `jQuery(formSelector).serialize()` on Blocks — the block form has no classic inputs worth serializing
  - Card-fields `createOrder` `.catch` — in block mode, stashes the server-side error message on `angelleyeOrder.blockCreateOrderError` instead of calling `showError()` (which targets classic DOM)
  - Card-fields `onApprove` — in block mode, triggers `angelleye_ppcp_cc_approved` with the order id instead of calling `checkoutFormCapture()`
  - Card-fields `onError` — in block mode, emits `angelleye_ppcp_cc_error` with either the stashed create-order message or the parsed SDK error
  - `submit_paypal_cc_form` invalid-fields branch — emits `angelleye_ppcp_cc_error` tagged `context: 'card_invalid'` so the subscriber routes it inline next to the card fields instead of the top-of-form notice area
  - `renderHostedButtons()` — empties `#angelleye_ppcp_cc-card-number`, `#angelleye_ppcp_cc-card-expiry`, `#angelleye_ppcp_cc-card-cvc` before the SDK's `.render()` calls. Fixes the doubled iframes on Blocks validation-error re-renders
- **`checkout-block/angelleye-ppcp-cc-block.php`** — PPCP-CC place-order button label changed from hardcoded "Proceed to PayPal" to `__('Place order', ...)` wrapped in a new `angelleye_ppcp_cc_place_order_button_text` filter. The smart-button gateway's "Proceed to PayPal" label is unchanged (it still redirects)

## Risk assessment

- **Classic checkout (any gateway, any flow)** — every JS change is gated on `angelleyeOrder.ppcp_block_mode === true`, every PHP guard on `angelleye_ppcp_is_store_api_request()`. Both evaluate to `false` on classic flows, so the old code paths run unchanged. The only unconditional change outside those gates is the normalized array returns in `process_payment()`, which replace implicit `null` with `['result' => 'failure', ...]` — WC treats both the same way in classic.
- **Blocks + PPCP-CC happy path** — covered by Scenarios B and C
- **Blocks + PPCP-CC any failure** — defensive fallthroughs prevent the fatal, stuck spinner, or stuck `hasPaymentError`
- **Blocks + smart-button gateway** — unchanged behaviorally; only Layer 2 (defensive `exit()` guards + normalized returns) applies
- **Admin order capture / subscriptions / FunnelKit upsells** — `angelleye_ppcp_order_capture_request()` signature and return contract untouched; fixes are at the gateway boundary only

## Test plan

Pre-req: WooCommerce with Blocks checkout at a known URL, PPCP configured in sandbox.

### Scenarios

- [ ] **A. ArrayMerge failure** — Blocks checkout if any plugin fails the validation, fill shipping, "Use same address for billing" on, select PPCP-CC, fill test card, click Place order. Before: `array_merge()` fatal + stuck spinner. After: error notice validation failed at top of form, page scrolls to it, spinner clears, user can retry
- [ ] **B. Happy path + same billing checkbox** — Blocks checkout, fill shipping only (leave the same-address checkbox on), PPCP-CC, enter test card, Place order. Verify:
  - wc-api `create_order` has populated `address.billing` (copied from shipping)
  - SDK runs 3DS inline
  - `/wc/store/v1/checkout` POSTs with `payment_data: [{key: "paypal_order_id", value: ...}]`
  - WC order created with correct billing, capture completes, redirect to thank-you
- [ ] **C. Happy path + separate billing** — Uncheck "Use same address for billing", fill billing separately, same as B. Verify billing is distinct from shipping on the created order
- [ ] **D. Card-invalid error placement** — Fill shipping, leave card empty, click Place order. Expect: "Unfortunately, your credit card details are not valid…" **next to the payment method block**, NOT at the top
- [ ] **E. Non-card error placement + scroll** — Fill everything, trigger a server error (e.g. tamper session nonce). Expect: error **at top of form**, page auto-scrolls to it
- [ ] **F. Retry after error** — Trigger any error (D or E), correct the issue, click Place order again. Expect: second click reaches our subscriber (check Network tab for new wc-api request). No "There was a problem with your payment option." fallback from Blocks
- [ ] **G. Validation-errors deferral** — Leave required fields (shipping first name / email) empty, click Place order. Expect: Blocks' own inline field errors appear, our notice says "Please complete all required fields before continuing." at top, **no** "credit card details are not valid" message
- [ ] **H. Double card fields regression** — On Blocks, click Place order with empty everything, get validation errors, fill shipping, click Place order again. Expect: card fields still rendered once (no doubles)
- [ ] **I. Button label** — Select PPCP-CC on Blocks checkout. Expect: button reads "Place order" (not "Proceed to PayPal"). Select the smart-button gateway. Expect: button still reads "Proceed to PayPal"
- [ ] **J. Order attribution and custom fields** — Install WC Order Attribution block (or any third-party plugin that extends the Blocks checkout schema), place an order via PPCP-CC, verify the attribution / custom field data lands on the WC order without any PFW-side mapping code
- [ ] **K. Blocks + smart-button gateway (regression)** — Click the PayPal express button on Blocks checkout, approve in popup, return. Expect: unchanged behavior
- [ ] **L. Classic checkout PPCP-CC (regression)** — Non-blocks `/checkout/`, fill form, enter test card, Place order. Expect: legacy jQuery flow completes unchanged
- [ ] **M. Classic checkout smart button (regression)** — Non-blocks checkout, PayPal smart button, approve, return. Expect: unchanged
- [ ] **N. Failing capture on Blocks (defensive)** — Force `angelleye_ppcp_order_capture_request()` to return `false` (expire `_paypal_order_id` mid-flow, or tamper the session). Expect: no fatal. `process_payment()` returns `['result' => 'failure', ...]`, Blocks shows a generic error notice, user can retry
- [ ] **O. Admin capture / refund (regression)** — Capture an authorized order from WP admin. Expect: unchanged — admin hooks call `angelleye_ppcp_order_capture_request()` directly, not via `process_payment()`

### Log / Network checks

- `wp-content/uploads/wc-logs/angelleye-ppcp-*.log` — confirm no `array_merge(): Argument #2 must be of type array` fatals after Scenario A
- DevTools Network tab — on Blocks success path, confirm `/wc/store/v1/checkout` fires **after** `wc-api/create_order` resolves, never before / in parallel
- DevTools React devtools — confirm `Content_PPCP_CC` unmount cleanup runs on navigation away from Blocks checkout (subscription unsubscribe)

## Files changed

```
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/class-wc-gateway-cc-angelleye.php
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/ppcp-cc.js
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-angelleye-common-functions.js
```
