### PR TITLE
Fix race on Blocks checkout first load: buttons/card fields missing

### DIFF
--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -1112,7 +1112,14 @@ const angelleyeOrder = {
             });
         },
         handleRaceConditionOnWooHooks: () => {
-            jQuery(document.body).on('updated_cart_totals payment_method_selected updated_checkout ppcp_block_ready', function (event, data) {
+            // trigger_angelleye_ppcp_cc is fired by the Blocks-checkout
+            // Content_PPCP_CC React component's useEffect on mount. On first
+            // page load it races the async PayPal SDK load: the real handler
+            // in handleWooEvents() is only wired up AFTER the SDK finishes
+            // loading (inside initSmartButtons), so without queuing this
+            // event here the early trigger is lost and the express button /
+            // hosted card fields never render until the user refreshes.
+            jQuery(document.body).on('updated_cart_totals payment_method_selected updated_checkout ppcp_block_ready trigger_angelleye_ppcp_cc', function (event, data) {
                 if (!angelleyeOrder.isPendingEventTriggering) {
                     angelleyeOrder.addEventsForCallback(event.type, event, data);
                 }


### PR DESCRIPTION
## Summary

On **WooCommerce Blocks checkout**, the PayPal express button and PPCP-CC hosted card fields sometimes don't render on **first page load** — a page refresh fixes them. This is a first-load-only race between the async PayPal SDK script and the Blocks React components.

## Root cause

[wc-gateway-ppcp-angelleye-public.js](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-gateway-ppcp-angelleye-public.js) calls two lifecycle hooks at different times:

1. **`handleRaceConditionOnWooHooks()`** runs **immediately** (line 119), before the SDK loads. It installs a queue listener that captures early events so they can be replayed once real handlers are ready.
2. **`handleWooEvents()`** runs **after** the PayPal SDK finishes loading, from inside `initSmartButtons()` (line 91). It installs the *real* listener that calls `renderPaymentButtons()`.

[ppcp-cc.js](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/ppcp-cc.js) `Content_PPCP_CC` React component fires `trigger_angelleye_ppcp_cc` on mount, and [wc-angelleye-common-functions.js](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-angelleye-common-functions.js) `handleWooEvents()` listens for it at [line 1110](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-angelleye-common-functions.js#L1110) to call `renderPaymentButtons()`.

The queue list at [handleRaceConditionOnWooHooks:1115](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-angelleye-common-functions.js#L1115) was missing `trigger_angelleye_ppcp_cc`:

```js
// before
jQuery(document.body).on('updated_cart_totals payment_method_selected updated_checkout ppcp_block_ready', ...)
```

### Cold first-load timeline (broken)

```
t=0    wc-angelleye-common-functions.js + public.js parse
t=0    handleRaceConditionOnWooHooks() installs queue listener
       (only watching updated_cart_totals, payment_method_selected,
        updated_checkout, ppcp_block_ready — NOT trigger_angelleye_ppcp_cc)
t=0    angelleyeLoadAsyncLibs(paypalSdkLoadCallback) starts PayPal SDK fetch
t=50   Blocks React mounts Content_PPCP_CC
t=50   useEffect → jQuery(document.body).trigger('trigger_angelleye_ppcp_cc')
       ── no queue handler → event lost into the void
       ── no real handler yet (handleWooEvents not called)
t=800  PayPal SDK finishes loading
t=800  paypalSdkLoadCallback → initSmartButtons()
t=800  handleWooEvents() installs the real listener for trigger_angelleye_ppcp_cc
t=800  triggerPendingEvents() replays the queue
       ── but trigger_angelleye_ppcp_cc wasn't in the queue
       ── nothing replays
       ── renderPaymentButtons never called
Result: express button + hosted card field iframes not in DOM.
```

### Refresh (works)

SDK is cached in the browser, so `initSmartButtons()` runs at ~t=50ms — *before* `Content_PPCP_CC` mounts. When the React component eventually fires `trigger_angelleye_ppcp_cc`, the real handler in `handleWooEvents()` is already live → render succeeds. That's why refresh fixes it and masked the bug.

### Confirmed live

Running `angelleyeOrder.renderPaymentButtons()` manually in the console while stuck on the broken first-load state makes both the express button and hosted card fields appear — proving everything is loaded and the only thing missing was a call to the render function.

## Fix

One-line change: add `trigger_angelleye_ppcp_cc` to the event list in `handleRaceConditionOnWooHooks()`.

```js
// after
jQuery(document.body).on('updated_cart_totals payment_method_selected updated_checkout ppcp_block_ready trigger_angelleye_ppcp_cc', ...)
```

New cold first-load timeline:

```
t=0    handleRaceConditionOnWooHooks() queue listener now includes
       trigger_angelleye_ppcp_cc
t=50   Blocks React mounts Content_PPCP_CC → trigger fires → queued
t=800  initSmartButtons() → handleWooEvents() → real handler installed
t=800  triggerPendingEvents() replays trigger_angelleye_ppcp_cc
       → real handler runs → renderPaymentButtons() → DOM populated
```

## Files changed

- [ppcp-gateway/js/wc-angelleye-common-functions.js](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/js/wc-angelleye-common-functions.js) — one event name added to the queue listener in `angelleyeOrder.hooks.handleRaceConditionOnWooHooks`, plus a comment explaining the race

## Test plan

Test on a site with **Blocks checkout** enabled (not classic).

- [ ] **Cold first load (the repro)** — clear browser cache, navigate to the Blocks checkout page. Verify **without refreshing**:
  - PayPal express button renders at the top of the Blocks checkout
  - PPCP-CC hosted card field iframes (number / expiry / cvc) render inside the card form
  - No "PayPal lib loaded, initialize buttons" → "initSmartButtons" → render-nothing sequence in console
- [ ] **Refresh path (should still work)** — after loading the page once, hard-refresh it. Buttons and card fields still render correctly (confirms we haven't regressed the SDK-cached path)
- [ ] **Block checkout ↔ cart toggling** — add an item, remove it, re-add it. Blocks re-renders the checkout when cart contents change. Verify buttons still mount correctly after each cart mutation
- [ ] **Payment method switching** — click between PPCP-CC and any other payment method in the Blocks radio control. Card fields should disappear / reappear correctly
- [ ] **Classic checkout regression** — visit `/checkout/` on a classic-checkout site (non-Blocks). Smart button and hosted card fields render as before. No console warnings
- [ ] **Order-pay page regression** — open a `/checkout/order-pay/{id}` link. Same button/field render as before
- [ ] **Manual retry still works** — on the broken pre-fix build, `angelleyeOrder.renderPaymentButtons()` in the console was the reliable workaround. After the fix it should no longer be necessary, but the call itself should continue to work as a manual re-render path (no double-render / no broken state)

## Notes

- The sibling gateway `#angelleye_ppcp_checkout_top` / `#angelleye_ppcp_checkout_shortcode` selectors printed in the console log are noise from `renderSmartButton()` iterating its static list — those DOM nodes don't exist on Blocks and the function silently skips them. Not related to this fix
- Considered moving `handleWooEvents()` registration out of `initSmartButtons()` to run immediately alongside `handleRaceConditionOnWooHooks()`, but that broader refactor risks breaking the classic-checkout `payment_method_selected` and `updated_checkout` flows that depend on the current ordering. Adding the missing event name to the queue is the minimal, targeted fix
