### PR TITLE
Guard block integration is_active() against missing gateway classes

### DIFF
--- a/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
+++ b/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
@@ -15,6 +15,14 @@ final class AngellEYE_PPCP_CC_Block extends AbstractPaymentMethodType {
     }
 
     public function is_active() {
+        // See angelleye-ppcp-checkout-block.php::is_active() for the same
+        // rationale: parent gateway classes are loaded lazily via the
+        // woocommerce_payment_gateways filter, and Blocks can call is_active()
+        // from script-dependency hooks on pages where WC never boots its
+        // gateways (e.g. wp-login.php under WP Defender Mask Login).
+        if (!class_exists('WC_Gateway_CC_AngellEYE')) {
+            return false;
+        }
         $this->gateway = new WC_Gateway_CC_AngellEYE();
         return $this->gateway->is_available();
     }

--- a/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php
+++ b/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php
@@ -15,6 +15,15 @@ final class AngellEYE_PPCP_Checkout_Block extends AbstractPaymentMethodType {
     }
 
     public function is_active() {
+        // Parent gateway classes are loaded via the woocommerce_payment_gateways
+        // filter, which only fires when something calls WC()->payment_gateways().
+        // Blocks' PaymentMethodRegistry calls is_active() from wp_print_scripts
+        // hooks that can fire on pages where WC never boots its gateways — e.g.
+        // wp-login.php rendered by WP Defender's Mask Login. Without this guard
+        // instantiating the class would throw a fatal and white-screen login.
+        if (!class_exists('WC_Gateway_PPCP_AngellEYE')) {
+            return false;
+        }
         $this->gateway = new WC_Gateway_PPCP_AngellEYE();
         return $this->gateway->is_available();
     }


### PR DESCRIPTION
## Summary

Fixes an `Uncaught Error: Class "WC_Gateway_PPCP_AngellEYE" not found` fatal that white-screens certain pages (most commonly `wp-login.php` when served through WP Defender's Mask Login) on sites running PayPal for WooCommerce alongside WooCommerce Blocks.

## Repro / stack trace from the field

```
Uncaught Error: Class "WC_Gateway_PPCP_AngellEYE" not found
  in /wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php:18

#0  PaymentMethodRegistry::get_all_active_registered() at line 28
#1  array_filter(integrations, AngellEYE_PPCP_Checkout_Block->is_active)
#2  PaymentMethodRegistry::get_all_active_registered()
#3  PaymentMethodRegistry->get_all_active_payment_method_script_dependencies()
#4  Api->verify_payment_methods_dependencies('')            ← hooked to wp_print_scripts
#5  do_action('wp_print_scripts')
#6  wp_print_head_scripts('')
#7  do_action('login_head')                                  ← from wp-login.php
#8  WP_Defender\Controller\Mask_Login->show_login_page()
#9  WP_Defender\Controller\Mask_Login->handle_login_request()
#10 do_action('init')
```

## Root cause

Both Blocks integration classes have an unguarded `new WC_Gateway_*_AngellEYE()` inside `is_active()`:

```php
// paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php
public function is_active() {
    $this->gateway = new WC_Gateway_PPCP_AngellEYE();   // ← fatal if class not loaded
    return $this->gateway->is_available();
}

// paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
public function is_active() {
    $this->gateway = new WC_Gateway_CC_AngellEYE();     // ← same problem
    return $this->gateway->is_available();
}
```

The integration classes themselves are loaded at `woocommerce_blocks_loaded` via `require_once`. Their parent gateway classes (`WC_Gateway_PPCP_AngellEYE`, `WC_Gateway_CC_AngellEYE`) are **not** — those are loaded lazily through `angelleye_add_paypal_pro_gateway()`, which only runs when something calls `WC()->payment_gateways()` (which triggers the `woocommerce_payment_gateways` filter).

On a normal frontend checkout request, `WC()->payment_gateways()` is called early, so parents load before Blocks ever touches the registry. On a `wp-login.php` request served through WP Defender's Mask Login, WC does **not** boot its payment gateways — but Blocks' `Api::verify_payment_methods_dependencies()` is still hooked to `wp_print_scripts`, which fires via `login_head` → `wp_print_head_scripts`. That path walks `PaymentMethodRegistry::get_all_active_registered()`, which calls `is_active()` on every registered Blocks integration. PFW's `is_active()` runs, tries to `new WC_Gateway_PPCP_AngellEYE()`, the class is absent, PHP throws, WordPress dies.

The result is a `E_ERROR` at `angelleye-ppcp-checkout-block.php:18` and a completely broken login page.

## Fix

Guard each `is_active()` with `class_exists()`. If the parent gateway class isn't loaded, return `false` (inactive) instead of instantiating it.

```php
// angelleye-ppcp-checkout-block.php
public function is_active() {
    if (!class_exists('WC_Gateway_PPCP_AngellEYE')) {
        return false;
    }
    $this->gateway = new WC_Gateway_PPCP_AngellEYE();
    return $this->gateway->is_available();
}

// angelleye-ppcp-cc-block.php
public function is_active() {
    if (!class_exists('WC_Gateway_CC_AngellEYE')) {
        return false;
    }
    $this->gateway = new WC_Gateway_CC_AngellEYE();
    return $this->gateway->is_available();
}
```

Returning `false` is the correct semantics for these code paths: on pages where WC hasn't booted its payment gateways, nobody is actually checking out, so the Blocks registry should just treat the payment method as inactive for that request. When a real checkout render happens later, WC will have booted its gateways by then and `is_active()` returns the correct value as before.

## Files changed

- [paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php) — `class_exists('WC_Gateway_PPCP_AngellEYE')` guard in `is_active()`
- [paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php) — `class_exists('WC_Gateway_CC_AngellEYE')` guard in `is_active()`

## Risk assessment

- **Normal frontend checkout (cart, /checkout/, Blocks checkout)** — no behavioral change. `WC()->payment_gateways()` runs during `init`, so the parent classes are loaded before Blocks' `PaymentMethodRegistry` calls `is_active()`, the `class_exists()` guard is `true`, and the method returns `$this->gateway->is_available()` exactly as before.
- **wp-login.php / Mask Login / admin AJAX endpoints that print head scripts** — fatal becomes a clean `return false`. Blocks treats the method as inactive for that request (which it effectively is — nobody is checking out on login), the page renders, login works again.
- **Other edge-case entry points** (rewrite rules intercepted by security plugins, REST endpoints that print scripts, etc.) — same benign fallthrough. Any such page was already broken before this PR; now it renders.
- **No database / settings / session side effects** — `is_active()` is a pure read.

## Test plan

- [ ] **Repro scenario** — install WP Defender, enable Mask Login with a custom login URL, visit the custom login URL in an incognito window. **Before**: white screen + PHP fatal in the error log. **After**: login page renders normally, no fatal
- [ ] **Normal Blocks checkout** — visit `/checkout/` on a site using the Checkout block. Express PayPal button + PPCP-CC hosted card fields render as before. Place a test order end-to-end — completes with no regression
- [ ] **Normal classic checkout** — visit `/checkout/` on a site still using the classic shortcode. Gateways appear in the payment methods list, smart button + card fields render, test order completes
- [ ] **PayPal admin settings** — visit WooCommerce → Settings → Payments → PayPal (both gateways). Both settings screens open without error, values save correctly
- [ ] **`WC()->payment_gateways()` from init (PR #2174 scenario)** — install one of the plugins that triggered the original report (YayMail / CartFlows / WooCommerce PayPal Braintree) alongside PFW. Visit any frontend page. No fatal
- [ ] **wp-admin pages** — visit `/wp-admin/`, dashboard, orders list, plugins list. No fatal from the head-scripts path
- [ ] **Error log inspection** — after the test flow, grep `debug.log` and the PHP error log for any `Class "WC_Gateway_..." not found` occurrences. Should be zero

## Notes

- This is intentionally scoped to the two `is_active()` methods at the actual failing call sites. A heavier alternative — preloading the parent gateway classes inside the `woocommerce_blocks_loaded` action — would load gateway code on every admin and REST request and was rejected as disproportionate. The `class_exists()` guard is a single branch with zero overhead when the class is loaded.
