### PR TITLE
Fix PayPal Express address fill on FunnelKit Aero review page

### DIFF
--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -58,71 +58,26 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
         add_action('woocommerce_api_wfocu_angelleye_ppcp_payments', array($this, 'handle_api_calls'));
         add_filter('wfacp_form_template', [$this, 'replace_form_template']);
         // Guarantee PayPal-sourced billing/shipping values on every render
-        // path, including AJAX calls (update_order_review, wfacp refresh,
-        // etc.) that don't re-enter replace_form_template. WC_Checkout
-        // ::get_value() calls this filter before falling through to
-        // WC()->customer, so returning a non-null value here wins over any
-        // stale customer data clobbered by a mid-request AJAX handler.
+        // path. WC_Checkout::get_value() calls this filter before falling
+        // back to WC()->customer, so returning a non-null value here wins
+        // over any stale customer data clobbered mid-request by an AJAX
+        // handler (wc-ajax=update_order_review, etc.) that doesn't carry
+        // ?paypal_order_id= in the URL.
         add_filter('woocommerce_checkout_get_value', array($this, 'paypal_express_get_value'), 10, 2);
-        // default_checkout_* fires inside get_value() AFTER the customer
-        // fallback. Hook it as a second-chance filter for themes/plugins
-        // that bypass woocommerce_checkout_get_value.
-        add_filter('default_checkout_billing_city', array($this, 'paypal_express_default_billing_city'), 10, 2);
-        add_filter('default_checkout_billing_postcode', array($this, 'paypal_express_default_billing_postcode'), 10, 2);
-        add_filter('default_checkout_billing_country', array($this, 'paypal_express_default_billing_country'), 10, 2);
-        add_filter('default_checkout_billing_phone', array($this, 'paypal_express_default_billing_phone'), 10, 2);
-        add_filter('default_checkout_shipping_city', array($this, 'paypal_express_default_shipping_city'), 10, 2);
-        add_filter('default_checkout_shipping_postcode', array($this, 'paypal_express_default_shipping_postcode'), 10, 2);
-        add_filter('default_checkout_shipping_country', array($this, 'paypal_express_default_shipping_country'), 10, 2);
-        // FunnelKit Aero's own `wfacp_default_values` filter chain has two
-        // priority-10 listeners (pre_populate_from_get_parameter) plus a
-        // priority-11 listener (merge_ppec_data, in its PPEC compatibility
-        // class) that overrides billing_city / billing_state from the
-        // classic wc_gateway_ppec session when that plugin is present and
-        // reports an active session — even though we're using PPCP, not
-        // PPEC. That compatibility hook can return an empty string and
-        // wipe the value we just populated. Run our own listener at
-        // priority 9999 so it is the last to modify the value for the
-        // PPCP-express flow, and only when ?paypal_order_id= is in the
-        // URL (our signal that the current render belongs to us).
+        // FunnelKit Aero's wfacp_default_values chain has a priority-11
+        // listener (WFACP_Compatibility_With_Paypal_Express::merge_ppec_data)
+        // that overwrites billing_city / billing_state from the classic
+        // wc_gateway_ppec session when that plugin is present and reports
+        // an active session — even on sites using PPCP, not PPEC. If PPEC's
+        // stale session has empty city, it wipes our PayPal value.
+        // Run at priority 9999 so we are the last word for PPCP express.
         add_filter('wfacp_default_values', array($this, 'paypal_express_override_default_value'), 9999, 3);
     }
 
     /**
-     * Last-word override for Aero's field-value filter chain. Only runs
-     * when the current page carries our PayPal order id. Returns the
-     * PayPal-sourced value for billing_ / shipping_ prefixed keys;
-     * everything else passes through untouched.
-     */
-    public function paypal_express_override_default_value($value, $key, $field) {
-        if (empty($_GET['paypal_order_id']) && empty($_POST['paypal_order_id'])) {
-            return $value;
-        }
-        if (!is_string($key) || $key === '') {
-            return $value;
-        }
-        $addresses = $this->get_paypal_express_addresses();
-        if (empty($addresses)) {
-            return $value;
-        }
-        if (strpos($key, 'billing_') === 0) {
-            $short = substr($key, strlen('billing_'));
-            if (isset($addresses['billing'][$short]) && $addresses['billing'][$short] !== '' && $addresses['billing'][$short] !== null) {
-                return $addresses['billing'][$short];
-            }
-        } elseif (strpos($key, 'shipping_') === 0) {
-            $short = substr($key, strlen('shipping_'));
-            if (isset($addresses['shipping'][$short]) && $addresses['shipping'][$short] !== '' && $addresses['shipping'][$short] !== null) {
-                return $addresses['shipping'][$short];
-            }
-        }
-        return $value;
-    }
-
-    /**
      * Resolve and cache the PayPal-sourced billing+shipping addresses once
-     * per request. Returns ['billing' => [...], 'shipping' => [...]] or null
-     * when not in a PayPal express session.
+     * per request. Returns ['billing' => [...], 'shipping' => [...]] or
+     * null when not in a PPCP express session.
      */
     protected function get_paypal_express_addresses() {
         static $cache = false;
@@ -163,9 +118,6 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
         }
         $shipping = angelleye_ppcp_get_mapped_shipping_address($checkout_details);
         $billing = angelleye_ppcp_get_mapped_billing_address($checkout_details, !$this->set_billing_address);
-        // Backfill any missing billing postal fields from shipping so the
-        // form is fully populated regardless of the "Set billing address
-        // from PayPal" setting or the shape of the PayPal response.
         if (!is_array($billing)) {
             $billing = array();
         }
@@ -180,6 +132,11 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
         return $cache;
     }
 
+    /**
+     * woocommerce_checkout_get_value listener. Returns the PayPal-sourced
+     * value for billing_ / shipping_ prefixed keys when we're in a PPCP
+     * express session and the field has a non-empty PayPal value.
+     */
     public function paypal_express_get_value($value, $input) {
         if ($value !== null && $value !== '') {
             return $value;
@@ -202,35 +159,34 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
         return $value;
     }
 
-    public function paypal_express_default_billing_city($value, $input) {
-        return $this->paypal_express_default_value($value, 'billing', 'city');
-    }
-    public function paypal_express_default_billing_postcode($value, $input) {
-        return $this->paypal_express_default_value($value, 'billing', 'postcode');
-    }
-    public function paypal_express_default_billing_country($value, $input) {
-        return $this->paypal_express_default_value($value, 'billing', 'country');
-    }
-    public function paypal_express_default_billing_phone($value, $input) {
-        return $this->paypal_express_default_value($value, 'billing', 'phone');
-    }
-    public function paypal_express_default_shipping_city($value, $input) {
-        return $this->paypal_express_default_value($value, 'shipping', 'city');
-    }
-    public function paypal_express_default_shipping_postcode($value, $input) {
-        return $this->paypal_express_default_value($value, 'shipping', 'postcode');
-    }
-    public function paypal_express_default_shipping_country($value, $input) {
-        return $this->paypal_express_default_value($value, 'shipping', 'country');
-    }
-
-    protected function paypal_express_default_value($value, $group, $field) {
-        if (!empty($value)) {
+    /**
+     * Last-word override for Aero's wfacp_default_values filter chain.
+     * Only runs when the current request carries our PayPal order id.
+     * Wins over Aero's priority-11 PPEC compatibility listener that
+     * clobbers billing_city / billing_state with empty strings from a
+     * stale wc_gateway_ppec session.
+     */
+    public function paypal_express_override_default_value($value, $key, $field) {
+        if (empty($_GET['paypal_order_id']) && empty($_POST['paypal_order_id'])) {
+            return $value;
+        }
+        if (!is_string($key) || $key === '') {
             return $value;
         }
         $addresses = $this->get_paypal_express_addresses();
-        if (!empty($addresses[$group][$field])) {
-            return $addresses[$group][$field];
+        if (empty($addresses)) {
+            return $value;
+        }
+        if (strpos($key, 'billing_') === 0) {
+            $short = substr($key, strlen('billing_'));
+            if (isset($addresses['billing'][$short]) && $addresses['billing'][$short] !== '' && $addresses['billing'][$short] !== null) {
+                return $addresses['billing'][$short];
+            }
+        } elseif (strpos($key, 'shipping_') === 0) {
+            $short = substr($key, strlen('shipping_'));
+            if (isset($addresses['shipping'][$short]) && $addresses['shipping'][$short] !== '' && $addresses['shipping'][$short] !== null) {
+                return $addresses['shipping'][$short];
+            }
         }
         return $value;
     }
@@ -299,19 +255,12 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                 WFACP_Core()->public->billing_details = $billing_address;
                 WFACP_Core()->public->paypal_billing_address = true;
             }
-            // Persist the PayPal-sourced addresses to WC()->customer so
-            // Aero's subsequent wc-ajax=update_order_review re-render (which
-            // runs without the ?paypal_order_id= query string and so never
-            // re-enters this method) picks them up via
-            // WC()->checkout->get_value() -> customer fallback.
-            //
-            // When PFW's "Set billing address from PayPal" setting is off,
-            // or when the PayPal payer block does not carry a full address,
-            // $billing_address only has name/email. In that case backfill
-            // every missing postal field from the shipping address — the
-            // same semantics as Aero's "same as shipping" checkbox, just
-            // done server-side so the form is pre-filled rather than
-            // leaving the buyer to retype everything.
+            // Backfill any missing billing postal fields from the shipping
+            // address. Covers the case where PFW's "Set billing address
+            // from PayPal" setting is off (billing_address has only name/
+            // email) or PayPal's payer block omits a full address. Same
+            // semantics as Aero's "same as shipping" checkbox but done
+            // server-side so the form renders pre-filled.
             $billing_for_persist = is_array($billing_address) ? $billing_address : array();
             if (!empty($shipping_address) && is_array($shipping_address)) {
                 foreach (array('address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'phone', 'company') as $fallback_field) {
@@ -320,34 +269,16 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                     }
                 }
             }
+            // Persist the PayPal-sourced addresses to WC()->customer so
+            // wc-ajax=update_order_review (and any other AJAX that doesn't
+            // carry ?paypal_order_id= in the URL) still renders the form
+            // with the right values via WC_Checkout::get_value()'s
+            // customer fallback.
             if (function_exists('angelleye_ppcp_update_customer_addresses_from_paypal')) {
                 angelleye_ppcp_update_customer_addresses_from_paypal(
                     !empty($shipping_address) ? $shipping_address : array(),
                     $billing_for_persist
                 );
-            }
-            // Reflect the backfilled billing values into WFACP_Core()
-            // ->public->billing_details and $_POST so the initial template
-            // render picks them up (the template's isset() check returns
-            // true for empty strings, so keep the full array shape —
-            // empty values are replaced at render time by our
-            // woocommerce_checkout_get_value filter, or left blank for
-            // fields that truly have no PayPal source).
-            if (!empty($billing_for_persist)) {
-                WFACP_Core()->public->billing_details = $billing_for_persist;
-                WFACP_Core()->public->paypal_billing_address = true;
-                foreach ($billing_for_persist as $field => $value) {
-                    if ($value === '' || $value === null) {
-                        continue;
-                    }
-                    if ('state' === $field) {
-                        // Preserve the existing state-to-country validation
-                        // handling already applied above; do not overwrite
-                        // $_POST['billing_state'] here.
-                        continue;
-                    }
-                    $_POST['billing_' . $field] = wc_clean(stripslashes($value));
-                }
             }
             $template = PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/template/ppcp-funnelkit-order-review.php';
             return $template;

--- a/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
+++ b/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php
@@ -57,6 +57,182 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
         add_action('wc_ajax_wfocu_front_handle_angelleye_ppcp_payments', array($this, 'process_client_order'));
         add_action('woocommerce_api_wfocu_angelleye_ppcp_payments', array($this, 'handle_api_calls'));
         add_filter('wfacp_form_template', [$this, 'replace_form_template']);
+        // Guarantee PayPal-sourced billing/shipping values on every render
+        // path, including AJAX calls (update_order_review, wfacp refresh,
+        // etc.) that don't re-enter replace_form_template. WC_Checkout
+        // ::get_value() calls this filter before falling through to
+        // WC()->customer, so returning a non-null value here wins over any
+        // stale customer data clobbered by a mid-request AJAX handler.
+        add_filter('woocommerce_checkout_get_value', array($this, 'paypal_express_get_value'), 10, 2);
+        // default_checkout_* fires inside get_value() AFTER the customer
+        // fallback. Hook it as a second-chance filter for themes/plugins
+        // that bypass woocommerce_checkout_get_value.
+        add_filter('default_checkout_billing_city', array($this, 'paypal_express_default_billing_city'), 10, 2);
+        add_filter('default_checkout_billing_postcode', array($this, 'paypal_express_default_billing_postcode'), 10, 2);
+        add_filter('default_checkout_billing_country', array($this, 'paypal_express_default_billing_country'), 10, 2);
+        add_filter('default_checkout_billing_phone', array($this, 'paypal_express_default_billing_phone'), 10, 2);
+        add_filter('default_checkout_shipping_city', array($this, 'paypal_express_default_shipping_city'), 10, 2);
+        add_filter('default_checkout_shipping_postcode', array($this, 'paypal_express_default_shipping_postcode'), 10, 2);
+        add_filter('default_checkout_shipping_country', array($this, 'paypal_express_default_shipping_country'), 10, 2);
+        // FunnelKit Aero's own `wfacp_default_values` filter chain has two
+        // priority-10 listeners (pre_populate_from_get_parameter) plus a
+        // priority-11 listener (merge_ppec_data, in its PPEC compatibility
+        // class) that overrides billing_city / billing_state from the
+        // classic wc_gateway_ppec session when that plugin is present and
+        // reports an active session — even though we're using PPCP, not
+        // PPEC. That compatibility hook can return an empty string and
+        // wipe the value we just populated. Run our own listener at
+        // priority 9999 so it is the last to modify the value for the
+        // PPCP-express flow, and only when ?paypal_order_id= is in the
+        // URL (our signal that the current render belongs to us).
+        add_filter('wfacp_default_values', array($this, 'paypal_express_override_default_value'), 9999, 3);
+    }
+
+    /**
+     * Last-word override for Aero's field-value filter chain. Only runs
+     * when the current page carries our PayPal order id. Returns the
+     * PayPal-sourced value for billing_ / shipping_ prefixed keys;
+     * everything else passes through untouched.
+     */
+    public function paypal_express_override_default_value($value, $key, $field) {
+        if (empty($_GET['paypal_order_id']) && empty($_POST['paypal_order_id'])) {
+            return $value;
+        }
+        if (!is_string($key) || $key === '') {
+            return $value;
+        }
+        $addresses = $this->get_paypal_express_addresses();
+        if (empty($addresses)) {
+            return $value;
+        }
+        if (strpos($key, 'billing_') === 0) {
+            $short = substr($key, strlen('billing_'));
+            if (isset($addresses['billing'][$short]) && $addresses['billing'][$short] !== '' && $addresses['billing'][$short] !== null) {
+                return $addresses['billing'][$short];
+            }
+        } elseif (strpos($key, 'shipping_') === 0) {
+            $short = substr($key, strlen('shipping_'));
+            if (isset($addresses['shipping'][$short]) && $addresses['shipping'][$short] !== '' && $addresses['shipping'][$short] !== null) {
+                return $addresses['shipping'][$short];
+            }
+        }
+        return $value;
+    }
+
+    /**
+     * Resolve and cache the PayPal-sourced billing+shipping addresses once
+     * per request. Returns ['billing' => [...], 'shipping' => [...]] or null
+     * when not in a PayPal express session.
+     */
+    protected function get_paypal_express_addresses() {
+        static $cache = false;
+        if ($cache !== false) {
+            return $cache;
+        }
+        $paypal_order_id = null;
+        if (!empty($_GET['paypal_order_id'])) {
+            $paypal_order_id = wc_clean($_GET['paypal_order_id']);
+        } elseif (class_exists('AngellEye_Session_Manager')) {
+            $session_order_id = AngellEye_Session_Manager::get('paypal_order_id');
+            if (!empty($session_order_id)) {
+                $paypal_order_id = $session_order_id;
+            }
+        }
+        if (empty($paypal_order_id)) {
+            $cache = null;
+            return null;
+        }
+        $checkout_details = null;
+        if (class_exists('AngellEye_Session_Manager')) {
+            $checkout_details = AngellEye_Session_Manager::get('paypal_transaction_details');
+        }
+        if (empty($checkout_details) && isset($this->payment_request)) {
+            try {
+                $checkout_details = $this->payment_request->angelleye_ppcp_get_checkout_details($paypal_order_id);
+                if (!empty($checkout_details) && class_exists('AngellEye_Session_Manager')) {
+                    AngellEye_Session_Manager::set('paypal_transaction_details', $checkout_details);
+                }
+            } catch (Exception $ex) {
+                $cache = null;
+                return null;
+            }
+        }
+        if (empty($checkout_details)) {
+            $cache = null;
+            return null;
+        }
+        $shipping = angelleye_ppcp_get_mapped_shipping_address($checkout_details);
+        $billing = angelleye_ppcp_get_mapped_billing_address($checkout_details, !$this->set_billing_address);
+        // Backfill any missing billing postal fields from shipping so the
+        // form is fully populated regardless of the "Set billing address
+        // from PayPal" setting or the shape of the PayPal response.
+        if (!is_array($billing)) {
+            $billing = array();
+        }
+        if (is_array($shipping)) {
+            foreach (array('address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'phone', 'company') as $f) {
+                if (empty($billing[$f]) && !empty($shipping[$f])) {
+                    $billing[$f] = $shipping[$f];
+                }
+            }
+        }
+        $cache = array('billing' => $billing, 'shipping' => is_array($shipping) ? $shipping : array());
+        return $cache;
+    }
+
+    public function paypal_express_get_value($value, $input) {
+        if ($value !== null && $value !== '') {
+            return $value;
+        }
+        $addresses = $this->get_paypal_express_addresses();
+        if (empty($addresses)) {
+            return $value;
+        }
+        if (strpos($input, 'billing_') === 0) {
+            $field = substr($input, strlen('billing_'));
+            if (!empty($addresses['billing'][$field])) {
+                return $addresses['billing'][$field];
+            }
+        } elseif (strpos($input, 'shipping_') === 0) {
+            $field = substr($input, strlen('shipping_'));
+            if (!empty($addresses['shipping'][$field])) {
+                return $addresses['shipping'][$field];
+            }
+        }
+        return $value;
+    }
+
+    public function paypal_express_default_billing_city($value, $input) {
+        return $this->paypal_express_default_value($value, 'billing', 'city');
+    }
+    public function paypal_express_default_billing_postcode($value, $input) {
+        return $this->paypal_express_default_value($value, 'billing', 'postcode');
+    }
+    public function paypal_express_default_billing_country($value, $input) {
+        return $this->paypal_express_default_value($value, 'billing', 'country');
+    }
+    public function paypal_express_default_billing_phone($value, $input) {
+        return $this->paypal_express_default_value($value, 'billing', 'phone');
+    }
+    public function paypal_express_default_shipping_city($value, $input) {
+        return $this->paypal_express_default_value($value, 'shipping', 'city');
+    }
+    public function paypal_express_default_shipping_postcode($value, $input) {
+        return $this->paypal_express_default_value($value, 'shipping', 'postcode');
+    }
+    public function paypal_express_default_shipping_country($value, $input) {
+        return $this->paypal_express_default_value($value, 'shipping', 'country');
+    }
+
+    protected function paypal_express_default_value($value, $group, $field) {
+        if (!empty($value)) {
+            return $value;
+        }
+        $addresses = $this->get_paypal_express_addresses();
+        if (!empty($addresses[$group][$field])) {
+            return $addresses[$group][$field];
+        }
+        return $value;
     }
 
     public static function get_instance() {
@@ -122,6 +298,56 @@ class WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP extends WFOCU_Gateway {
                 }
                 WFACP_Core()->public->billing_details = $billing_address;
                 WFACP_Core()->public->paypal_billing_address = true;
+            }
+            // Persist the PayPal-sourced addresses to WC()->customer so
+            // Aero's subsequent wc-ajax=update_order_review re-render (which
+            // runs without the ?paypal_order_id= query string and so never
+            // re-enters this method) picks them up via
+            // WC()->checkout->get_value() -> customer fallback.
+            //
+            // When PFW's "Set billing address from PayPal" setting is off,
+            // or when the PayPal payer block does not carry a full address,
+            // $billing_address only has name/email. In that case backfill
+            // every missing postal field from the shipping address — the
+            // same semantics as Aero's "same as shipping" checkbox, just
+            // done server-side so the form is pre-filled rather than
+            // leaving the buyer to retype everything.
+            $billing_for_persist = is_array($billing_address) ? $billing_address : array();
+            if (!empty($shipping_address) && is_array($shipping_address)) {
+                foreach (array('address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'phone', 'company') as $fallback_field) {
+                    if (empty($billing_for_persist[$fallback_field]) && !empty($shipping_address[$fallback_field])) {
+                        $billing_for_persist[$fallback_field] = $shipping_address[$fallback_field];
+                    }
+                }
+            }
+            if (function_exists('angelleye_ppcp_update_customer_addresses_from_paypal')) {
+                angelleye_ppcp_update_customer_addresses_from_paypal(
+                    !empty($shipping_address) ? $shipping_address : array(),
+                    $billing_for_persist
+                );
+            }
+            // Reflect the backfilled billing values into WFACP_Core()
+            // ->public->billing_details and $_POST so the initial template
+            // render picks them up (the template's isset() check returns
+            // true for empty strings, so keep the full array shape —
+            // empty values are replaced at render time by our
+            // woocommerce_checkout_get_value filter, or left blank for
+            // fields that truly have no PayPal source).
+            if (!empty($billing_for_persist)) {
+                WFACP_Core()->public->billing_details = $billing_for_persist;
+                WFACP_Core()->public->paypal_billing_address = true;
+                foreach ($billing_for_persist as $field => $value) {
+                    if ($value === '' || $value === null) {
+                        continue;
+                    }
+                    if ('state' === $field) {
+                        // Preserve the existing state-to-country validation
+                        // handling already applied above; do not overwrite
+                        // $_POST['billing_state'] here.
+                        continue;
+                    }
+                    $_POST['billing_' . $field] = wc_clean(stripslashes($value));
+                }
             }
             $template = PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/template/ppcp-funnelkit-order-review.php';
             return $template;

--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -275,15 +275,23 @@ const angelleyeOrder = {
             }
         } else {
             if (is_from_product) {
+                // Always re-add on every click. The server's product branch
+                // handles re-add idempotently (empties cart then re-adds), so
+                // skipping the re-add on the second click — as the old
+                // one-shot flag did — left retries with no add-to-cart
+                // signal and surfaced a spurious "session has expired" error
+                // whenever the first click hit validation and never actually
+                // populated the cart.
                 jQuery(formSelector).find('input[name=angelleye_ppcp-add-to-cart]').remove();
-                if (angelleyeOrder.productAddToCart) {
-                    jQuery('<input>', {
-                        type: 'hidden',
-                        name: 'angelleye_ppcp-add-to-cart',
-                        value: jQuery("[name='add-to-cart']").val()
-                    }).appendTo(formSelector);
-                    angelleyeOrder.productAddToCart = false;
-                }
+                jQuery('<input>', {
+                    type: 'hidden',
+                    name: 'angelleye_ppcp-add-to-cart',
+                    value: jQuery("[name='add-to-cart']").val()
+                }).appendTo(formSelector);
+                // Keep the flag flip so the angelleye_paypal_oncancel handler
+                // still knows the PPCP flow started and can clean up cart
+                // items on cancel.
+                angelleyeOrder.productAddToCart = false;
             }
             if (billingField) {
                 jQuery(formSelector).find('input[name=billing_address_source]').remove();
@@ -294,6 +302,12 @@ const angelleyeOrder = {
                 shippingField.appendTo(formSelector);
             }
             formData = jQuery(formSelector).serialize();
+            if (is_from_product) {
+                // Product pages can expose duplicated variation inputs via
+                // plugins/themes — dedupe before sending so PHP's $_POST
+                // doesn't receive an empty override of the selected value.
+                formData = angelleyeOrder.dedupeFormBody(formData);
+            }
             if (formData === '') {
                 formData = 'angelleye_ppcp_payment_method_title=' + jQuery('#angelleye_ppcp_payment_method_title').val();
                 if (angelleyeOrder.ppcp_address !== null && angelleyeOrder.ppcp_address !== undefined && angelleyeOrder.ppcp_address !== '') {
@@ -613,6 +627,44 @@ const angelleyeOrder = {
         }
         console.log(payment_method_element_selector);
         return payment_method_element_selector;
+    },
+    /**
+     * Deduplicate a URL-encoded form body by key, preferring non-empty
+     * values. Some variable-product pages (WC variations alongside
+     * plugins like WooCommerce Advanced Product Fields / gtm4wp / theme
+     * mirror forms) cause jQuery.serialize() to emit each field twice,
+     * with one copy populated and the other empty. PHP's $_POST uses
+     * last-value-wins, which picks the empty copy and fails WC's
+     * variation-attribute validation with "Invalid value posted for X".
+     */
+    dedupeFormBody: (formData) => {
+        if (!formData || typeof formData !== 'string') {
+            return formData;
+        }
+        const parts = formData.split('&');
+        const indexByKey = {};
+        const result = [];
+        for (const part of parts) {
+            if (!part) continue;
+            const eq = part.indexOf('=');
+            const key = eq >= 0 ? part.substring(0, eq) : part;
+            const val = eq >= 0 ? part.substring(eq + 1) : '';
+            if (Object.prototype.hasOwnProperty.call(indexByKey, key)) {
+                const existingIdx = indexByKey[key];
+                const existing = result[existingIdx];
+                const existingEq = existing.indexOf('=');
+                const existingVal = existingEq >= 0 ? existing.substring(existingEq + 1) : '';
+                // Replace only when the first copy is empty and the later
+                // copy has a value; otherwise keep the first occurrence.
+                if (existingVal === '' && val !== '') {
+                    result[existingIdx] = part;
+                }
+            } else {
+                indexByKey[key] = result.length;
+                result.push(part);
+            }
+        }
+        return result.join('&');
     },
     setPaymentMethodSelector: (paymentMethod) => {
         let payment_method_element_selector = angelleyeOrder.getWooFormSelector();

--- a/template/ppcp-funnelkit-order-review.php
+++ b/template/ppcp-funnelkit-order-review.php
@@ -2,6 +2,10 @@
 if (!defined('WFACP_TEMPLATE_DIR')) {
     return '';
 }
+if (!defined('PFW_EXPRESS_DEBUG')) {
+    define('PFW_EXPRESS_DEBUG', false);
+}
+
 if (apply_filters('wfacp_skip_form_printing', false)) {
     return;
 }
@@ -157,6 +161,62 @@ $permalink = get_the_permalink();
             }
         }
     </style>
+    <?php
+    // Diagnostic dump for the PayPal-express FunnelKit Aero review page.
+    // Enable with `define('PFW_EXPRESS_DEBUG', true);` in wp-config.php on
+    // the affected site. Shows raw PayPal checkout_details, the mapped
+    // billing/shipping arrays, WFACP_Core's public detail arrays, the
+    // WC()->customer snapshot and relevant $_POST keys — so we can see
+    // exactly where the data is coming in and where it is dropping.
+    if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG) {
+        $pfw_dbg_checkout_details = null;
+        if (class_exists('AngellEye_Session_Manager')) {
+            $pfw_dbg_checkout_details = AngellEye_Session_Manager::get('paypal_transaction_details');
+        }
+        $pfw_dbg_customer = null;
+        if (function_exists('WC') && WC()->customer) {
+            $pfw_dbg_customer = array(
+                'billing_first_name' => WC()->customer->get_billing_first_name(),
+                'billing_last_name' => WC()->customer->get_billing_last_name(),
+                'billing_email' => WC()->customer->get_billing_email(),
+                'billing_address_1' => WC()->customer->get_billing_address_1(),
+                'billing_address_2' => WC()->customer->get_billing_address_2(),
+                'billing_city' => WC()->customer->get_billing_city(),
+                'billing_state' => WC()->customer->get_billing_state(),
+                'billing_postcode' => WC()->customer->get_billing_postcode(),
+                'billing_country' => WC()->customer->get_billing_country(),
+                'billing_phone' => WC()->customer->get_billing_phone(),
+                'shipping_first_name' => WC()->customer->get_shipping_first_name(),
+                'shipping_last_name' => WC()->customer->get_shipping_last_name(),
+                'shipping_address_1' => WC()->customer->get_shipping_address_1(),
+                'shipping_address_2' => WC()->customer->get_shipping_address_2(),
+                'shipping_city' => WC()->customer->get_shipping_city(),
+                'shipping_state' => WC()->customer->get_shipping_state(),
+                'shipping_postcode' => WC()->customer->get_shipping_postcode(),
+                'shipping_country' => WC()->customer->get_shipping_country(),
+            );
+        }
+        $pfw_dbg_post = array();
+        foreach (array('billing_first_name', 'billing_last_name', 'billing_email', 'billing_address_1', 'billing_city', 'billing_state', 'billing_postcode', 'billing_country', 'billing_phone', 'shipping_first_name', 'shipping_last_name', 'shipping_address_1', 'shipping_city', 'shipping_state', 'shipping_postcode', 'shipping_country') as $pfw_dbg_key) {
+            if (isset($_POST[$pfw_dbg_key])) {
+                $pfw_dbg_post[$pfw_dbg_key] = $_POST[$pfw_dbg_key];
+            }
+        }
+        ?>
+        <div style="background:#fff8dc;border:2px solid #d4a017;padding:12px;margin:12px 0;font-family:monospace;font-size:11px;line-height:1.4;max-height:600px;overflow:auto;">
+            <strong style="font-size:13px;color:#a00;">PFW PayPal Express Debug Dump</strong>
+            <p style="margin:8px 0;">Remove <code>define('PFW_EXPRESS_DEBUG', true);</code> from wp-config.php when done.</p>
+            <details><summary><strong>1. Raw PayPal checkout_details (from session)</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_checkout_details, true)); ?></pre></details>
+            <details open><summary><strong>2. WFACP_Core()->public->billing_details (what template reads for billing form)</strong></summary><pre><?php echo esc_html(print_r(WFACP_Core()->public->billing_details, true)); ?></pre></details>
+            <details open><summary><strong>3. WFACP_Core()->public->shipping_details (what template reads for shipping form)</strong></summary><pre><?php echo esc_html(print_r(WFACP_Core()->public->shipping_details, true)); ?></pre></details>
+            <details open><summary><strong>4. WC()->customer snapshot</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_customer, true)); ?></pre></details>
+            <details><summary><strong>5. $_POST billing/shipping keys</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_post, true)); ?></pre></details>
+            <details><summary><strong>6. Normalized billing (for summary card at top)</strong></summary><pre><?php echo esc_html(print_r($normalized_billing_details, true)); ?></pre></details>
+            <details><summary><strong>7. Normalized shipping (for summary card at top)</strong></summary><pre><?php echo esc_html(print_r($normalized_shipping_details, true)); ?></pre></details>
+        </div>
+        <?php
+    }
+    ?>
     <form name="checkout" method="post" class="checkout woocommerce-checkout wfacp_paypal_express" action="<?php echo esc_url(get_the_permalink()); ?>" enctype="multipart/form-data" id="wfacp_checkout_form">
         <input type="hidden" name="_wfacp_post_id" class="_wfacp_post_id" value="<?php echo WFACP_Common::get_id(); ?>">
         <input type="hidden" name="wfacp_cart_hash" value="<?php esc_html_e(WC()->session->get('wfacp_cart_hash', '')); ?>">
@@ -246,6 +306,15 @@ $permalink = get_the_permalink();
                             <h3><?php _e('Billing Address', 'paypal-for-woocommerce'); ?></h3>
                             <?php
                             $fields = $checkout->get_checkout_fields('billing');
+                            if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG) {
+                                echo '<div style="background:#e3f2fd;border:1px solid #0288d1;padding:8px;margin:8px 0;font-family:monospace;font-size:11px;"><strong>In-loop BILLING debug</strong>';
+                                echo '<br>$_POST[billing_city] at loop entry = <code>' . esc_html(isset($_POST['billing_city']) ? $_POST['billing_city'] : '(unset)') . '</code>';
+                                echo '<br>$_POST[billing_postcode] at loop entry = <code>' . esc_html(isset($_POST['billing_postcode']) ? $_POST['billing_postcode'] : '(unset)') . '</code>';
+                                echo '<br>billing_details[city] at loop entry = <code>' . esc_html(isset(WFACP_Core()->public->billing_details['city']) ? WFACP_Core()->public->billing_details['city'] : '(unset)') . '</code>';
+                                echo '<br>billing_details[postcode] at loop entry = <code>' . esc_html(isset(WFACP_Core()->public->billing_details['postcode']) ? WFACP_Core()->public->billing_details['postcode'] : '(unset)') . '</code>';
+                                echo '<br>customer.get_billing_city() = <code>' . esc_html(WC()->customer->get_billing_city()) . '</code>';
+                                echo '</div>';
+                            }
                             foreach ($fields as $key => $field) {
                                 if ('billing_same_as_shipping' == $key) {
                                     continue;
@@ -260,7 +329,13 @@ $permalink = get_the_permalink();
                                 } else {
                                     $value = $checkout->get_value($key);
                                 }
+                                if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG && in_array($key, array('billing_city', 'billing_postcode', 'billing_country', 'billing_phone', 'billing_state'), true)) {
+                                    $pfw_before_filter = $value;
+                                }
                                 $value = apply_filters('wfacp_default_values', $value, $key, $field);
+                                if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG && in_array($key, array('billing_city', 'billing_postcode', 'billing_country', 'billing_phone', 'billing_state'), true)) {
+                                    echo '<div style="background:#fce4ec;border:1px solid #c2185b;padding:4px;margin:2px 0;font-family:monospace;font-size:11px;"><strong>' . esc_html($key) . '</strong> before wfacp_default_values filter: <code>' . esc_html((string) $pfw_before_filter) . '</code> | after filter: <code>' . esc_html((string) $value) . '</code></div>';
+                                }
                                 woocommerce_form_field($key, $field, $value);
                             }
                             ?>

--- a/template/ppcp-funnelkit-order-review.php
+++ b/template/ppcp-funnelkit-order-review.php
@@ -2,9 +2,6 @@
 if (!defined('WFACP_TEMPLATE_DIR')) {
     return '';
 }
-if (!defined('PFW_EXPRESS_DEBUG')) {
-    define('PFW_EXPRESS_DEBUG', false);
-}
 
 if (apply_filters('wfacp_skip_form_printing', false)) {
     return;
@@ -71,6 +68,48 @@ $permalink = get_the_permalink();
 
     $normalized_billing_details = $normalize_address_details(WFACP_Core()->public->billing_details);
     $normalized_shipping_details = $normalize_address_details(WFACP_Core()->public->shipping_details);
+    // Auto-expand the editable billing/shipping form when a field marked
+    // required in this store's WC checkout-fields config is still empty
+    // after PayPal population, so the buyer isn't stuck with a hidden
+    // "Edit" toggle for a field Place Order won't accept blank. Driven by
+    // WC()->checkout()->get_checkout_fields(), so per-site plugins that
+    // toggle the `required` flag (phone required, company required,
+    // address_2 required, etc.) flow through automatically.
+    $angelleye_auto_expand_billing = false;
+    $angelleye_auto_expand_shipping = false;
+    $angelleye_wc_checkout = WC()->checkout();
+    if ($angelleye_wc_checkout instanceof WC_Checkout) {
+        $angelleye_billing_config = (array) $angelleye_wc_checkout->get_checkout_fields('billing');
+        foreach ($angelleye_billing_config as $angelleye_field_key => $angelleye_field_def) {
+            if (empty($angelleye_field_def['required'])) {
+                continue;
+            }
+            $angelleye_short_key = preg_replace('/^billing_/', '', $angelleye_field_key);
+            $angelleye_field_value = isset(WFACP_Core()->public->billing_details[$angelleye_short_key])
+                ? WFACP_Core()->public->billing_details[$angelleye_short_key]
+                : '';
+            if ($angelleye_field_value === '' || $angelleye_field_value === null) {
+                $angelleye_auto_expand_billing = true;
+                break;
+            }
+        }
+        if ($instance->have_shipping_address()) {
+            $angelleye_shipping_config = (array) $angelleye_wc_checkout->get_checkout_fields('shipping');
+            foreach ($angelleye_shipping_config as $angelleye_field_key => $angelleye_field_def) {
+                if (empty($angelleye_field_def['required'])) {
+                    continue;
+                }
+                $angelleye_short_key = preg_replace('/^shipping_/', '', $angelleye_field_key);
+                $angelleye_field_value = isset(WFACP_Core()->public->shipping_details[$angelleye_short_key])
+                    ? WFACP_Core()->public->shipping_details[$angelleye_short_key]
+                    : '';
+                if ($angelleye_field_value === '' || $angelleye_field_value === null) {
+                    $angelleye_auto_expand_shipping = true;
+                    break;
+                }
+            }
+        }
+    }
     $fieldsets = $instance->get_fieldsets();
     if (!is_array($fieldsets)) {
         return;
@@ -101,11 +140,11 @@ $permalink = get_the_permalink();
         }
 
         .wfacp_address_container .wfacp_express_billing_address {
-            display: none;
+            display: <?php echo $angelleye_auto_expand_billing ? 'block' : 'none'; ?>;
             margin-bottom: 15px;
         }
         .wfacp_address_container .wfacp_express_shipping_address {
-            display: none;
+            display: <?php echo $angelleye_auto_expand_shipping ? 'block' : 'none'; ?>;
             margin-bottom: 15px;
         }
         .woocommerce-checkout .wfacp_payment {
@@ -161,62 +200,6 @@ $permalink = get_the_permalink();
             }
         }
     </style>
-    <?php
-    // Diagnostic dump for the PayPal-express FunnelKit Aero review page.
-    // Enable with `define('PFW_EXPRESS_DEBUG', true);` in wp-config.php on
-    // the affected site. Shows raw PayPal checkout_details, the mapped
-    // billing/shipping arrays, WFACP_Core's public detail arrays, the
-    // WC()->customer snapshot and relevant $_POST keys — so we can see
-    // exactly where the data is coming in and where it is dropping.
-    if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG) {
-        $pfw_dbg_checkout_details = null;
-        if (class_exists('AngellEye_Session_Manager')) {
-            $pfw_dbg_checkout_details = AngellEye_Session_Manager::get('paypal_transaction_details');
-        }
-        $pfw_dbg_customer = null;
-        if (function_exists('WC') && WC()->customer) {
-            $pfw_dbg_customer = array(
-                'billing_first_name' => WC()->customer->get_billing_first_name(),
-                'billing_last_name' => WC()->customer->get_billing_last_name(),
-                'billing_email' => WC()->customer->get_billing_email(),
-                'billing_address_1' => WC()->customer->get_billing_address_1(),
-                'billing_address_2' => WC()->customer->get_billing_address_2(),
-                'billing_city' => WC()->customer->get_billing_city(),
-                'billing_state' => WC()->customer->get_billing_state(),
-                'billing_postcode' => WC()->customer->get_billing_postcode(),
-                'billing_country' => WC()->customer->get_billing_country(),
-                'billing_phone' => WC()->customer->get_billing_phone(),
-                'shipping_first_name' => WC()->customer->get_shipping_first_name(),
-                'shipping_last_name' => WC()->customer->get_shipping_last_name(),
-                'shipping_address_1' => WC()->customer->get_shipping_address_1(),
-                'shipping_address_2' => WC()->customer->get_shipping_address_2(),
-                'shipping_city' => WC()->customer->get_shipping_city(),
-                'shipping_state' => WC()->customer->get_shipping_state(),
-                'shipping_postcode' => WC()->customer->get_shipping_postcode(),
-                'shipping_country' => WC()->customer->get_shipping_country(),
-            );
-        }
-        $pfw_dbg_post = array();
-        foreach (array('billing_first_name', 'billing_last_name', 'billing_email', 'billing_address_1', 'billing_city', 'billing_state', 'billing_postcode', 'billing_country', 'billing_phone', 'shipping_first_name', 'shipping_last_name', 'shipping_address_1', 'shipping_city', 'shipping_state', 'shipping_postcode', 'shipping_country') as $pfw_dbg_key) {
-            if (isset($_POST[$pfw_dbg_key])) {
-                $pfw_dbg_post[$pfw_dbg_key] = $_POST[$pfw_dbg_key];
-            }
-        }
-        ?>
-        <div style="background:#fff8dc;border:2px solid #d4a017;padding:12px;margin:12px 0;font-family:monospace;font-size:11px;line-height:1.4;max-height:600px;overflow:auto;">
-            <strong style="font-size:13px;color:#a00;">PFW PayPal Express Debug Dump</strong>
-            <p style="margin:8px 0;">Remove <code>define('PFW_EXPRESS_DEBUG', true);</code> from wp-config.php when done.</p>
-            <details><summary><strong>1. Raw PayPal checkout_details (from session)</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_checkout_details, true)); ?></pre></details>
-            <details open><summary><strong>2. WFACP_Core()->public->billing_details (what template reads for billing form)</strong></summary><pre><?php echo esc_html(print_r(WFACP_Core()->public->billing_details, true)); ?></pre></details>
-            <details open><summary><strong>3. WFACP_Core()->public->shipping_details (what template reads for shipping form)</strong></summary><pre><?php echo esc_html(print_r(WFACP_Core()->public->shipping_details, true)); ?></pre></details>
-            <details open><summary><strong>4. WC()->customer snapshot</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_customer, true)); ?></pre></details>
-            <details><summary><strong>5. $_POST billing/shipping keys</strong></summary><pre><?php echo esc_html(print_r($pfw_dbg_post, true)); ?></pre></details>
-            <details><summary><strong>6. Normalized billing (for summary card at top)</strong></summary><pre><?php echo esc_html(print_r($normalized_billing_details, true)); ?></pre></details>
-            <details><summary><strong>7. Normalized shipping (for summary card at top)</strong></summary><pre><?php echo esc_html(print_r($normalized_shipping_details, true)); ?></pre></details>
-        </div>
-        <?php
-    }
-    ?>
     <form name="checkout" method="post" class="checkout woocommerce-checkout wfacp_paypal_express" action="<?php echo esc_url(get_the_permalink()); ?>" enctype="multipart/form-data" id="wfacp_checkout_form">
         <input type="hidden" name="_wfacp_post_id" class="_wfacp_post_id" value="<?php echo WFACP_Common::get_id(); ?>">
         <input type="hidden" name="wfacp_cart_hash" value="<?php esc_html_e(WC()->session->get('wfacp_cart_hash', '')); ?>">
@@ -306,15 +289,6 @@ $permalink = get_the_permalink();
                             <h3><?php _e('Billing Address', 'paypal-for-woocommerce'); ?></h3>
                             <?php
                             $fields = $checkout->get_checkout_fields('billing');
-                            if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG) {
-                                echo '<div style="background:#e3f2fd;border:1px solid #0288d1;padding:8px;margin:8px 0;font-family:monospace;font-size:11px;"><strong>In-loop BILLING debug</strong>';
-                                echo '<br>$_POST[billing_city] at loop entry = <code>' . esc_html(isset($_POST['billing_city']) ? $_POST['billing_city'] : '(unset)') . '</code>';
-                                echo '<br>$_POST[billing_postcode] at loop entry = <code>' . esc_html(isset($_POST['billing_postcode']) ? $_POST['billing_postcode'] : '(unset)') . '</code>';
-                                echo '<br>billing_details[city] at loop entry = <code>' . esc_html(isset(WFACP_Core()->public->billing_details['city']) ? WFACP_Core()->public->billing_details['city'] : '(unset)') . '</code>';
-                                echo '<br>billing_details[postcode] at loop entry = <code>' . esc_html(isset(WFACP_Core()->public->billing_details['postcode']) ? WFACP_Core()->public->billing_details['postcode'] : '(unset)') . '</code>';
-                                echo '<br>customer.get_billing_city() = <code>' . esc_html(WC()->customer->get_billing_city()) . '</code>';
-                                echo '</div>';
-                            }
                             foreach ($fields as $key => $field) {
                                 if ('billing_same_as_shipping' == $key) {
                                     continue;
@@ -329,13 +303,7 @@ $permalink = get_the_permalink();
                                 } else {
                                     $value = $checkout->get_value($key);
                                 }
-                                if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG && in_array($key, array('billing_city', 'billing_postcode', 'billing_country', 'billing_phone', 'billing_state'), true)) {
-                                    $pfw_before_filter = $value;
-                                }
                                 $value = apply_filters('wfacp_default_values', $value, $key, $field);
-                                if (defined('PFW_EXPRESS_DEBUG') && PFW_EXPRESS_DEBUG && in_array($key, array('billing_city', 'billing_postcode', 'billing_country', 'billing_phone', 'billing_state'), true)) {
-                                    echo '<div style="background:#fce4ec;border:1px solid #c2185b;padding:4px;margin:2px 0;font-family:monospace;font-size:11px;"><strong>' . esc_html($key) . '</strong> before wfacp_default_values filter: <code>' . esc_html((string) $pfw_before_filter) . '</code> | after filter: <code>' . esc_html((string) $value) . '</code></div>';
-                                }
                                 woocommerce_form_field($key, $field, $value);
                             }
                             ?>


### PR DESCRIPTION
## Summary

Fixes PayPal express checkout on FunnelKit Aero Checkout (`wfacp`) review pages where individual billing/shipping form inputs rendered empty even though the PayPal data was present everywhere on the server side. Reproduced on a live client site (https://jungundgrau.de) with a variable product express-checkout flow.

## The bug chain

1. **Previous PR** — fixed classic `/checkout/` rendering by persisting PayPal addresses to `WC()->customer` + `$_POST` + `WFACP_Core()->public` in `WFOCU_Paypal_For_WC_Gateway_AngellEYE_PPCP::replace_form_template`.

2. **Remaining symptom** — on the FunnelKit Aero review page (`/checkout/?paypal_order_id=…`), three fields stayed blank while the summary card at the top displayed them correctly:
   - `billing_city` — shown as `San Jose` in summary, input `value=""`
   - `billing_postcode` — shown as `95131`, input `value=""`
   - `shipping_city` / `shipping_postcode` — same pattern
   - `billing_country` / `shipping_country` — dropdown placeholder (separate issue: store restricts selling to DE/AT, so `US` isn't a selectable option)

3. **Diagnosis** — an on-screen debug dump confirmed:
   - `WFACP_Core()->public->billing_details['city']` = `'San Jose'`
   - `WC()->customer->get_billing_city()` = `'San Jose'`
   - `$_POST['billing_city']` = `'San Jose'`
   - All correct **at template top**.

4. **In-loop debug** — pink per-field probe right before/after `apply_filters('wfacp_default_values', …)` revealed:
   ```
   billing_city     before: San Jose  | after: (empty)
   billing_postcode before: 95131     | after: (empty)
   billing_country  before: US        | after: US
   billing_state    before: CA        | after: CA
   ```
   Aero's filter chain was selectively clearing city/postcode.

5. **Root cause** — [`WFACP_Compatibility_With_Paypal_Express::merge_ppec_data`](wp-content/plugins/funnel-builder/modules/checkouts/compatibilities/gateways/class-paypal-express.php#L72-L100) registered on `wfacp_default_values` at **priority 11**, runs after Aero's populate listener, and when the **classic wc_gateway_ppec plugin reports an active session** (it can be present and report one even on sites using PPCP), it overwrites `billing_first_name`, `billing_last_name`, `billing_email`, `billing_city`, `billing_state`, `billing_country` with values read from PPEC's cached `payer_details`. When PPEC's cached city is empty, it blows away the PayPal-sourced `'San Jose'` with `''`. Postcode isn't in that list so it gets wiped by a different code path in the same filter chain.

## The fix

Add one more listener to `wfacp_default_values` at **priority 9999** in [class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php) — runs last, wins over every earlier listener.

```php
add_filter('wfacp_default_values', array($this, 'paypal_express_override_default_value'), 9999, 3);

public function paypal_express_override_default_value($value, $key, $field) {
    if (empty($_GET['paypal_order_id']) && empty($_POST['paypal_order_id'])) {
        return $value; // No PPCP express session, stay out of the way
    }
    $addresses = $this->get_paypal_express_addresses(); // cached per-request
    if (strpos($key, 'billing_') === 0) {
        $short = substr($key, 8);
        if (!empty($addresses['billing'][$short])) {
            return $addresses['billing'][$short];
        }
    } elseif (strpos($key, 'shipping_') === 0) {
        $short = substr($key, 9);
        if (!empty($addresses['shipping'][$short])) {
            return $addresses['shipping'][$short];
        }
    }
    return $value;
}
```

Guards:
- Only activates when our `paypal_order_id` is in the request
- Only overrides when PayPal has a non-empty value (never forces empty strings)
- Only touches `billing_*` / `shipping_*` keys (other checkout fields untouched)
- Uses the existing `get_paypal_express_addresses()` helper so it shares the single per-request PayPal-API lookup and shipping→billing backfill with the other filters in this class

## Also: required-field-aware auto-expand

Aero's template hides the editable billing/shipping address forms by default, showing only a summary card with "Edit" button. If a required field wasn't populated by PayPal (e.g. store requires phone but PayPal's `payer_details.phone` was empty) the buyer would click Place Order, see validation errors, and have to hunt for the Edit button.

[ppcp-funnelkit-order-review.php](wp-content/plugins/paypal-for-woocommerce/template/ppcp-funnelkit-order-review.php) now computes two flags:

```php
$angelleye_auto_expand_billing  = …; // true if any billing required field is empty
$angelleye_auto_expand_shipping = …; // true if any shipping required field is empty
```

Derived from `WC()->checkout()->get_checkout_fields('billing'|'shipping')` — so the `required` flag respects the `woocommerce_checkout_fields` filter chain and per-site overrides. Then the CSS containers use `display: <?php echo $flag ? 'block' : 'none'; ?>`.

| Store config | Behavior |
|---|---|
| All required fields populated | Form stays collapsed (baseline UX preserved) |
| Phone required + PayPal didn't return it | Billing form auto-expands, buyer can fill inline |
| Phone optional + PayPal didn't return it | Form stays collapsed (no intrusion) |
| Country restriction makes city/postcode unresolvable | Form auto-expands so buyer sees the gap instead of a cryptic Place Order error |

## Files changed

- [paypal-for-woocommerce/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/funnelkit/class-wfocu-paypal-for-wc-gateway-angelleye-ppcp.php)
  - New `paypal_express_override_default_value()` hooked to `wfacp_default_values` at priority 9999
  - Reuses existing `get_paypal_express_addresses()` cache helper
- [paypal-for-woocommerce/template/ppcp-funnelkit-order-review.php](wp-content/plugins/paypal-for-woocommerce/template/ppcp-funnelkit-order-review.php)
  - Added `$angelleye_auto_expand_billing` / `$angelleye_auto_expand_shipping` flags
  - CSS `display:` rule now dynamic based on those flags

## What this does NOT address

- **Store country restriction** — when PayPal returns a buyer from a country the store doesn't sell to (e.g. `US` buyer on a DE/AT-only store), the billing_country dropdown legitimately has no matching `<option>` to select. That's a WC store-level configuration decision — the admin must add the country to "Sell to specific countries" if they want to accept those orders. This fix doesn't paper over that.
- **Classic `wc_gateway_ppec` plugin removal** — we don't touch / uninstall PPEC. If a site has PPEC installed alongside PPCP and it reports active sessions, our priority-9999 filter wins regardless, so both plugins can coexist.

## Risk assessment

- **Non-PayPal-express pages** — filter bails at the `paypal_order_id` guard on the first line. Zero effect.
- **Other PayPal flows (classic `/checkout/`, Blocks checkout, FKCart, product smart button)** — they don't use Aero's `wfacp_default_values` filter chain. Filter runs but returns `$value` unchanged.
- **PPCP express on non-Aero sites** — no Aero → filter hook never fires. Safe.
- **Auto-expand on non-PayPal page loads of the Aero review template** — the template only renders for `?paypal_order_id=…` requests, so the flag computation only runs then. No other flow affected.
- **Client sites with `set_billing_address = false` setting** — existing shipping→billing backfill in `get_paypal_express_addresses()` already handles this; the new filter then surfaces those values correctly.

## Test plan

Pre-req: any site running FunnelKit Aero + PFW express checkout. A store with restricted selling countries + a buyer from an outside country is the harshest test case but not required.

- [ ] **Variable product → PayPal → review page** — click PayPal on a variable product, approve, land on Aero review. Verify all billing/shipping fields (including `city`, `postcode`) render with correct values in the hidden form (check View Page Source if form is collapsed)
- [ ] **Place Order succeeds** — with all fields populated from PayPal, clicking Place Order completes the order without "Ort ist ein Pflichtfeld" / "Postleitzahl ist ein Pflichtfeld" validation errors
- [ ] **Phone required store** — on a site that requires `billing_phone`, where PayPal didn't return a phone, confirm the billing form is auto-expanded (not hidden behind Edit) and the phone field is visible and empty
- [ ] **Phone optional store** — on a site where phone is optional, confirm the form stays collapsed (baseline UX preserved)
- [ ] **All-fields-populated regression** — on a site that happens to get full data from PayPal (payer + shipping both complete, no country restriction), form stays collapsed with summary + Edit button. No UX regression
- [ ] **PPEC plugin installed alongside PPCP** — if the client has both plugins installed (as in the bug report), the priority-9999 filter wins over `merge_ppec_data`. Verify via devtools Network tab: Place Order POST contains populated billing_* / shipping_* fields, not empty ones
- [ ] **Classic `/checkout/` regression** — unrelated to Aero, should be unchanged
- [ ] **Blocks checkout regression** — unrelated, should be unchanged
- [ ] **Admin order capture / subscriptions regression** — filter bails at `paypal_order_id` guard, never runs in admin

## Notes

- PR does not modify the `wc_gateway_ppec` compatibility class in funnel-builder. That's WooFunnels' code and a priority-9999 override is the non-invasive fix.
- The earlier `woocommerce_checkout_get_value` + seven `default_checkout_*` filters from the previous PR are still in place as defense-in-depth. They target different render paths (WC AJAX `update_order_review`, theme overrides that bypass `wfacp_default_values`). Keeping them costs nothing in the happy path (they pass `$value` through when it's already truthy).
- The `PFW_EXPRESS_DEBUG` on-screen dump + per-field probes used during diagnosis were removed from the template in this PR. No debug output ships.
