### PR TITLE
feat: Add Payment Summary section to Partially Paid Order email

### DIFF
--- a/classes/wc-email-customer-partial-paid-order.php
+++ b/classes/wc-email-customer-partial-paid-order.php
@@ -4,6 +4,12 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 
+// Shared capture-aggregation + formatting helpers used by both the
+// HTML and plain-text templates for this email.
+if (!class_exists('AngellEYE_PPCP_Partial_Payment_Data', false)) {
+    require_once PAYPAL_FOR_WOOCOMMERCE_DIR_PATH . '/ppcp-gateway/includes/class-angelleye-ppcp-partial-payment-data.php';
+}
+
 if (!class_exists('WC_Email_Partially_Paid_Order', false)) :
 
     class WC_Email_Partially_Paid_Order extends WC_Email {

--- a/ppcp-gateway/includes/class-angelleye-ppcp-partial-payment-data.php
+++ b/ppcp-gateway/includes/class-angelleye-ppcp-partial-payment-data.php
@@ -1,0 +1,159 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('AngellEYE_PPCP_Partial_Payment_Data', false)) {
+
+    /**
+     * Shared data-collection + formatting helpers for the Partially Paid
+     * order email templates (HTML and plain text). Keeps the capture
+     * aggregation, refund subtraction, de-duplication and date-formatting
+     * logic in one place so the two template files stay thin — they only
+     * handle markup and layout.
+     *
+     * Consumers:
+     *   template/emails/angelleye-customer-partial-paid-order.php
+     *   template/emails/plain/angelleye-customer-partial-paid-order.php
+     */
+    final class AngellEYE_PPCP_Partial_Payment_Data {
+
+        /**
+         * Aggregate every PayPal capture recorded on a WC_Order's line
+         * items into a single ordered collection, subtract refund
+         * amounts, and compute the outstanding balance.
+         *
+         * The writer at class-angelleye-paypal-ppcp-payment.php stores the
+         * same capture record (same _ppcp_transaction_id) on every cart
+         * item included in the capture. We dedupe by transaction id so
+         * "Total Paid" and "Payments Received" are counted exactly once
+         * per capture.
+         *
+         * Each capture record may also carry a total_refund_amount field
+         * set during the refund flow — subtract it from the displayed
+         * amount so figures stay accurate after partial refunds.
+         *
+         * @param WC_Order $order
+         * @return array {
+         *     @type array $captures       txn_id => [date, date_raw, amount]
+         *     @type float $total_captured Sum of (transaction_amount - refund) across unique captures
+         *     @type float $order_total    $order->get_total() as float
+         *     @type float $balance        order_total - total_captured (positive = due, negative = over)
+         *     @type string $currency      Order currency code
+         * }
+         */
+        public static function get_capture_summary($order) {
+            $summary = array(
+                'captures' => array(),
+                'total_captured' => 0.0,
+                'order_total' => 0.0,
+                'balance' => 0.0,
+                'currency' => '',
+            );
+
+            if (!is_a($order, 'WC_Order')) {
+                return $summary;
+            }
+
+            $summary['currency'] = $order->get_currency();
+            $summary['order_total'] = (float) $order->get_total();
+
+            $all_captures = array();
+            $total_captured = 0.0;
+
+            foreach ($order->get_items() as $item_id => $item) {
+                $captures = wc_get_order_item_meta($item_id, '_ppcp_capture_details', true);
+                if (empty($captures) || !is_array($captures)) {
+                    continue;
+                }
+                foreach ($captures as $capture) {
+                    if (!isset($capture['_ppcp_transaction_amount'])) {
+                        continue;
+                    }
+                    $txn_id = $capture['_ppcp_transaction_id'] ?? '';
+                    if ($txn_id === '' || isset($all_captures[$txn_id])) {
+                        continue;
+                    }
+                    $amount = (float) $capture['_ppcp_transaction_amount']
+                              - (float) ($capture['total_refund_amount'] ?? 0);
+                    $total_captured += $amount;
+                    $all_captures[$txn_id] = array(
+                        'date_raw' => $capture['_ppcp_transaction_date'] ?? '',
+                        'amount' => $amount,
+                    );
+                }
+            }
+
+            // Chronological sort; guard strtotime('' / false) === false so
+            // malformed dates don't produce undefined ordering.
+            uasort($all_captures, function ($a, $b) {
+                $a_ts = !empty($a['date_raw']) ? strtotime($a['date_raw']) : 0;
+                $b_ts = !empty($b['date_raw']) ? strtotime($b['date_raw']) : 0;
+                return ($a_ts ?: 0) - ($b_ts ?: 0);
+            });
+
+            // Pre-format each capture date via WC's localized formatter
+            // so international stores see their configured date/time
+            // format and timezone instead of the m/d/y H:i string the
+            // writer persists.
+            foreach ($all_captures as $txn_id => $cap) {
+                $all_captures[$txn_id]['date'] = self::format_capture_date($cap['date_raw']);
+            }
+
+            $summary['captures'] = $all_captures;
+            $summary['total_captured'] = $total_captured;
+            $summary['balance'] = $summary['order_total'] - $total_captured;
+
+            return $summary;
+        }
+
+        /**
+         * Reparse a raw capture date string and format it for display
+         * using the store's locale + timezone. Falls back to the raw
+         * string when parsing fails so we never swallow the data.
+         *
+         * @param string $raw Date string persisted by the capture writer.
+         * @return string
+         */
+        public static function format_capture_date($raw) {
+            if (empty($raw)) {
+                return '';
+            }
+            $ts = strtotime($raw);
+            if (!$ts) {
+                return (string) $raw;
+            }
+            try {
+                $dt = new WC_DateTime('@' . $ts);
+                $dt->setTimezone(new DateTimeZone(wc_timezone_string()));
+                return wc_format_datetime($dt);
+            } catch (Exception $e) {
+                return (string) $raw;
+            }
+        }
+
+        /**
+         * Format an amount for the plain-text email. `wc_price()` returns
+         * HTML wrapped in <span> / <bdi> with HTML entities for currency
+         * (&euro;, &nbsp;). `strip_tags` removes the tags but leaves
+         * entities raw, which plain-text mail clients render literally.
+         * This helper strips tags AND decodes entities so the customer
+         * sees "549,00 €" instead of "549,00&nbsp;&euro;".
+         *
+         * @param float  $amount
+         * @param string $currency Currency code (e.g. EUR, USD).
+         * @return string
+         */
+        public static function format_plain_price($amount, $currency) {
+            $html = wc_price((float) $amount, array('currency' => $currency));
+            return trim(html_entity_decode(
+                wp_strip_all_tags($html),
+                ENT_QUOTES,
+                'UTF-8'
+            ));
+        }
+
+    }
+
+}

--- a/template/emails/angelleye-customer-partial-paid-order.php
+++ b/template/emails/angelleye-customer-partial-paid-order.php
@@ -11,10 +11,82 @@ do_action('woocommerce_email_header', $email_heading, $email);
 <p><?php printf(esc_html__('Hi %s,', 'paypal-for-woocommerce'), esc_html($order->get_billing_first_name())); ?></p>
 <?php ?>
 <p><?php printf(esc_html__('Just to let you know &mdash; we\'ve received your order #%s, and it is now being processed:', 'paypal-for-woocommerce'), esc_html($order->get_order_number())); ?></p>
-
 <?php
 do_action('woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email);
+?>
 
+<?php
+// Capture aggregation + refund subtraction + date localization live in
+// AngellEYE_PPCP_Partial_Payment_Data (ppcp-gateway/includes/).
+// Required by classes/wc-email-customer-partial-paid-order.php, so the
+// helper class is guaranteed to be loaded by the time this template
+// renders.
+$pfw_summary = AngellEYE_PPCP_Partial_Payment_Data::get_capture_summary($order);
+$all_captures = $pfw_summary['captures'];
+$total_captured = $pfw_summary['total_captured'];
+$order_total = $pfw_summary['order_total'];
+$balance = $pfw_summary['balance'];
+$pfw_currency = $pfw_summary['currency'];
+
+if ($total_captured > 0) :
+?>
+<div style="margin-bottom: 20px; padding: 15px; background-color: #fef3c7; border-left: 4px solid #f59e0b;">
+    <p style="margin: 0 0 10px 0;"><strong><?php esc_html_e('Payment Summary', 'paypal-for-woocommerce'); ?></strong></p>
+    <table cellspacing="0" cellpadding="0" style="width: 100%; border-collapse: collapse;">
+        <tr>
+            <td style="padding: 6px 0;"><?php esc_html_e('Order Total:', 'paypal-for-woocommerce'); ?></td>
+            <td style="padding: 6px 0; text-align: right;"><?php echo wp_kses_post(wc_price($order_total, array('currency' => $pfw_currency))); ?></td>
+        </tr>
+        <tr>
+            <td colspan="2" style="padding: 10px 0 6px 0; border-top: 1px solid #e5e7eb;">
+                <strong><?php esc_html_e('Payments Received:', 'paypal-for-woocommerce'); ?></strong>
+            </td>
+        </tr>
+        <?php foreach ($all_captures as $txn_id => $capture_data) : ?>
+        <tr>
+            <td style="padding: 4px 0 4px 15px; font-size: 0.95em;">
+                <?php echo esc_html($capture_data['date']); ?>
+            </td>
+            <td style="padding: 4px 0; text-align: right; font-size: 0.95em;">
+                <?php echo wp_kses_post(wc_price($capture_data['amount'], array('currency' => $pfw_currency))); ?>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+        <tr>
+            <td style="padding: 6px 0; border-top: 1px solid #e5e7eb;">
+                <strong><?php esc_html_e('Total Paid:', 'paypal-for-woocommerce'); ?></strong>
+            </td>
+            <td style="padding: 6px 0; text-align: right; border-top: 1px solid #e5e7eb;">
+                <strong><?php echo wp_kses_post(wc_price($total_captured, array('currency' => $pfw_currency))); ?></strong>
+            </td>
+        </tr>
+        <?php if ($balance > 0) : ?>
+        <tr>
+            <td style="padding: 6px 0; border-top: 2px solid #d97706;">
+                <strong><?php esc_html_e('Balance Due:', 'paypal-for-woocommerce'); ?></strong>
+            </td>
+            <td style="padding: 6px 0; text-align: right; border-top: 2px solid #d97706;">
+                <strong><?php echo wp_kses_post(wc_price($balance, array('currency' => $pfw_currency))); ?></strong>
+            </td>
+        </tr>
+        <?php elseif ($balance < 0) : ?>
+        <tr>
+            <td style="padding: 6px 0; border-top: 2px solid #d97706;">
+                <strong><?php esc_html_e('Additional Amount Billed:', 'paypal-for-woocommerce'); ?></strong>
+            </td>
+            <td style="padding: 6px 0; text-align: right; border-top: 2px solid #d97706;">
+                <strong><?php echo wp_kses_post(wc_price(abs($balance), array('currency' => $pfw_currency))); ?></strong>
+            </td>
+        </tr>
+        <?php endif; ?>
+    </table>
+    <?php if ($balance > 0) : ?>
+    <p style="margin: 10px 0 0 0; font-size: 0.9em;"><?php esc_html_e('The remaining balance will be charged when additional items are ready to ship.', 'paypal-for-woocommerce'); ?></p>
+    <?php endif; ?>
+</div>
+<?php endif; ?>
+
+<?php
 do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email);
 
 do_action('woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email);

--- a/template/emails/plain/angelleye-customer-partial-paid-order.php
+++ b/template/emails/plain/angelleye-customer-partial-paid-order.php
@@ -13,6 +13,57 @@ echo sprintf(esc_html__('Just to let you know &mdash; we\'ve received your order
 
 do_action('woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email);
 
+// Capture aggregation + refund subtraction + date localization +
+// plain-text currency formatting all live in
+// AngellEYE_PPCP_Partial_Payment_Data (ppcp-gateway/includes/).
+// Required by classes/wc-email-customer-partial-paid-order.php, so the
+// helper class is guaranteed to be loaded by the time this template
+// renders.
+$pfw_summary = AngellEYE_PPCP_Partial_Payment_Data::get_capture_summary($order);
+$all_captures = $pfw_summary['captures'];
+$total_captured = $pfw_summary['total_captured'];
+$order_total = $pfw_summary['order_total'];
+$balance = $pfw_summary['balance'];
+$pfw_currency = $pfw_summary['currency'];
+
+if ($total_captured > 0) :
+?>
+================================================================================
+<?php echo strtoupper(__('Payment Summary', 'paypal-for-woocommerce')); ?>
+
+================================================================================
+
+<?php _e('Order Total:', 'paypal-for-woocommerce'); ?>                                                    <?php echo esc_html(AngellEYE_PPCP_Partial_Payment_Data::format_plain_price($order_total, $pfw_currency)); ?>
+
+
+<?php echo strtoupper(__('Payments Received:', 'paypal-for-woocommerce')); ?>
+
+--------------------------------------------------------------------------------
+<?php foreach ($all_captures as $txn_id => $capture_data) : ?>
+  <?php echo esc_html($capture_data['date']); ?>                <?php echo str_pad(esc_html(AngellEYE_PPCP_Partial_Payment_Data::format_plain_price($capture_data['amount'], $pfw_currency)), 20, ' ', STR_PAD_LEFT); ?>
+
+<?php endforeach; ?>
+
+--------------------------------------------------------------------------------
+<?php _e('Total Paid:', 'paypal-for-woocommerce'); ?>                                                     <?php echo esc_html(AngellEYE_PPCP_Partial_Payment_Data::format_plain_price($total_captured, $pfw_currency)); ?>
+
+<?php if ($balance > 0) : ?>
+================================================================================
+<?php echo strtoupper(__('Balance Due:', 'paypal-for-woocommerce')); ?>                                                    <?php echo esc_html(AngellEYE_PPCP_Partial_Payment_Data::format_plain_price($balance, $pfw_currency)); ?>
+
+================================================================================
+
+<?php _e('The remaining balance will be charged when additional items are ready to ship.', 'paypal-for-woocommerce'); ?>
+
+<?php elseif ($balance < 0) : ?>
+================================================================================
+<?php echo strtoupper(__('Additional Amount Billed:', 'paypal-for-woocommerce')); ?>                                       <?php echo esc_html(AngellEYE_PPCP_Partial_Payment_Data::format_plain_price(abs($balance), $pfw_currency)); ?>
+
+================================================================================
+<?php endif; ?>
+
+<?php
+
 echo "\n----------------------------------------\n\n";
 
 do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email);


### PR DESCRIPTION
## Summary

Adds a **Payment Summary** section to the customer "Partially Paid Order" email so buyers can see at a glance what they've paid so far and what's still outstanding. Previously the email just confirmed the order had been partially paid — with no detail on *how much*, *when*, or *what remains*. Now the same email ships with a structured summary block that lists every capture the merchant has taken, subtracts any refunds, and shows a clear "Balance Due" amount.

Designed to work on stores that take a single authorization and capture in stages (pre-order, split shipping, subscription setup) as well as stores that issue partial refunds between captures.

## What's new in the email

The email body now includes a Payment Summary block that renders whenever the order has at least one recorded capture:

```
┌────────────────────────────────────────────────────┐
│ Payment Summary                                    │
├────────────────────────────────────────────────────┤
│ Order Total:                              €549,00  │
│                                                    │
│ Payments Received:                                 │
│   16.04.2026 14:32                        €100,00  │
│   18.04.2026 09:15                        €200,00  │
│   22.04.2026 11:48                        €200,00  │
│ ─────────────────────────────────────────────────  │
│ Total Paid:                               €500,00  │
│ ═════════════════════════════════════════════════  │
│ Balance Due:                               €49,00  │
│                                                    │
│ The remaining balance will be charged when         │
│ additional items are ready to ship.                │
└────────────────────────────────────────────────────┘
```

### Rows and behavior

- **Order Total** — `$order->get_total()`, formatted in the order's currency.
- **Payments Received** — one row per unique PayPal transaction, showing:
  - Localized date (uses the store's configured date format + timezone via `wc_format_datetime()` / `wc_timezone_string()`)
  - Captured amount, minus any refund already applied to that capture
  - Rows sorted chronologically
- **Total Paid** — sum of captured amounts after refunds.
- **Balance Due** — shown when `order_total > total_paid`, with an explanatory line ("The remaining balance will be charged when additional items are ready to ship.").
- **Additional Amount Billed** — shown when `total_paid > order_total` (rare, but possible when upsells or fees are captured beyond the original order total).
- The block collapses entirely when `total_captured = 0` — the email still renders with its original greeting, order details and footer, just without the summary box.

### Visual styling (HTML email)

- Amber/gold accent palette (`#fef3c7` background, `#f59e0b` left border, `#d97706` Balance Due separator) to signal "attention — payment in progress".
- Table-based layout with `cellspacing=0` / `cellpadding=0` and inline styles for broad email-client compatibility (Gmail, Outlook, Apple Mail).
- The Payments Received header and Total Paid row use a light gray separator (`#e5e7eb`); the Balance Due row uses a thicker amber separator to draw the eye.

### Plain-text variant

Matching ASCII-framed layout with `=======` and `-------` separators. Column-aligned amounts via `str_pad(...STR_PAD_LEFT)`. Currency values pass through a dedicated helper that strips HTML tags *and* decodes entities, so the plain-text body reads `€549,00` instead of the raw `&euro;` / `&nbsp;` tokens that `strip_tags(wc_price(...))` alone would leave behind.

## Architecture

All aggregation and formatting logic lives in a single new helper class so the HTML and plain-text templates share one source of truth.

```
paypal-for-woocommerce/
├── ppcp-gateway/includes/
│   └── class-angelleye-ppcp-partial-payment-data.php   ← NEW
├── classes/
│   └── wc-email-customer-partial-paid-order.php        ← require_once helper
└── template/emails/
    ├── angelleye-customer-partial-paid-order.php       ← thin (~6 lines of PHP)
    └── plain/
        └── angelleye-customer-partial-paid-order.php   ← thin (~6 lines of PHP)
```

### `AngellEYE_PPCP_Partial_Payment_Data`

Location: `ppcp-gateway/includes/` — matches sibling helpers (`class-angelleye-session-manager.php`, `ae-ppcp-constants.php`, `trait-angelleye-ppcp-core.php`).

`final class`, stateless, three public static methods:

| Method | Signature | Responsibility |
|---|---|---|
| `get_capture_summary` | `(WC_Order $order): array` | Walks `$order->get_items()`, reads `_ppcp_capture_details`, dedupes by `_ppcp_transaction_id`, subtracts `total_refund_amount`, sorts chronologically, localizes each date. Returns `['captures' => [txn_id => ['date', 'date_raw', 'amount']], 'total_captured', 'order_total', 'balance', 'currency']`. |
| `format_capture_date` | `(string $raw): string` | Reparses the writer's `m/d/y H:i` format via `strtotime` + `WC_DateTime`, applies `wc_timezone_string()`, formats via `wc_format_datetime()`. Falls back to raw input on parse failure so data is never lost. |
| `format_plain_price` | `(float $amount, string $currency): string` | `wc_price()` → `wp_strip_all_tags()` → `html_entity_decode(..., ENT_QUOTES, 'UTF-8')`. Used by plain-text template. |

### Template usage

Each template reduces to a single data-fetch call:

```php
$pfw_summary    = AngellEYE_PPCP_Partial_Payment_Data::get_capture_summary($order);
$all_captures   = $pfw_summary['captures'];
$total_captured = $pfw_summary['total_captured'];
$order_total    = $pfw_summary['order_total'];
$balance        = $pfw_summary['balance'];
$pfw_currency   = $pfw_summary['currency'];
```

From there it's pure markup — no logic, no arithmetic, no sorting.

### Loader wiring

[`wc-email-customer-partial-paid-order.php`](paypal-for-woocommerce/classes/wc-email-customer-partial-paid-order.php) `require_once`s the helper immediately after the `ABSPATH` guard, gated by `class_exists(..., false)`:

```php
if (!class_exists('AngellEYE_PPCP_Partial_Payment_Data', false)) {
    require_once PAYPAL_FOR_WOOCOMMERCE_DIR_PATH . '/ppcp-gateway/includes/class-angelleye-ppcp-partial-payment-data.php';
}
```

The email class is `include`d from the main plugin bootstrap at [paypal-for-woocommerce.php:1533](paypal-for-woocommerce/paypal-for-woocommerce.php#L1533) when WC builds its email registry, so the helper is guaranteed loaded before either template renders.

## Data sources

| Field | Source |
|---|---|
| Capture records | `wc_get_order_item_meta($item_id, '_ppcp_capture_details', true)` per line item |
| Transaction amount | `$capture['_ppcp_transaction_amount']` |
| Refund amount (subtracted) | `$capture['total_refund_amount']` (written during refund flow) |
| Transaction date | `$capture['_ppcp_transaction_date']` (writer stores `m/d/y H:i`) |
| Transaction id (dedup key) | `$capture['_ppcp_transaction_id']` |
| Order total | `$order->get_total()` |
| Currency | `$order->get_currency()` |
| Store date format / timezone | `wc_format_datetime()` + `wc_timezone_string()` |

## Design decisions worth calling out

- **Dedup at the consumer, not the writer.** The writer stores the same capture record on every cart item included in a capture (by design — it enables per-item refund tracking). Rather than change that invariant, the email consumer dedupes by transaction id. Keeps the admin capture-details view and the refund path untouched.
- **Refund subtraction happens inline with totaling.** `total_refund_amount` is subtracted from each capture's amount *before* adding to `total_captured`, so the single number "Total Paid" always reflects current net money received by the merchant.
- **Date parsing is defensive.** `strtotime('')` returns `false`; the sort comparator coalesces `false` / `0` so a single malformed capture date never puts the whole list into undefined order. A date we can't parse renders as the raw writer string rather than being dropped.
- **Plain-text currency formatter is a separate method.** Not an inline closure inside the template — themes overriding one template but not the other still call the same formatter, so the two variants can't drift on currency rendering.
- **`final class`, static methods, no state.** Makes the helper trivially unit-testable and impossible to subclass into something weird. Public API is exactly three methods.

## Files changed

- **New:** `ppcp-gateway/includes/class-angelleye-ppcp-partial-payment-data.php`
- **Modified:** `classes/wc-email-customer-partial-paid-order.php` — `require_once` the helper (5 lines added)
- **Modified:** `template/emails/angelleye-customer-partial-paid-order.php` — Payment Summary block added, helper call
- **Modified:** `template/emails/plain/angelleye-customer-partial-paid-order.php` — Payment Summary block added, helper call

## Test plan

- [ ] **Single capture, no refund** — authorize $100 order, capture $50. Email shows one row in Payments Received at `$50`, Total Paid `$50`, Balance Due `$50`, and the helper text "The remaining balance will be charged when additional items are ready to ship."
- [ ] **Single capture with partial refund** — capture $100, refund $20. Email shows Total Paid `$80` and the Additional Amount Billed / Balance Due rows reflect reality.
- [ ] **Multi-item capture** — 3 items summing to $100, capture all items in one go. Payments Received shows ONE row at `$100` (dedup by transaction id), not three rows at $100 each.
- [ ] **Multiple captures on different dates** — capture $30 day 1, $20 day 2. Two rows in Payments Received, chronologically ordered, dates localized.
- [ ] **Capture exceeds order total** — upsell pushes total captures above `order_total`. "Additional Amount Billed" row renders with the overage.
- [ ] **No captures recorded yet** — edge case where the email fires before any capture has been persisted. Payment Summary block collapses entirely; rest of email renders as before.
- [ ] **Plain-text render** — preview email in plain variant. Currency renders as `€549,00` (or locale equivalent), not `&euro;549,00` or `549,00&nbsp;&euro;`. Column alignment holds.
- [ ] **German/EU store** — on a store with German date/time format + EUR currency, both HTML and plain-text variants render dates per the store's `wc_date_format()` and amounts in the store's currency-symbol convention.
- [ ] **Malformed capture date** — inject an empty or garbage `_ppcp_transaction_date`. Sort order stable (no undefined behavior from `strtotime(false)`), offending row renders raw string. No PHP warnings.
- [ ] **Theme template override** — sites that copied the old template into `wp-content/themes/<theme>/woocommerce/emails/angelleye-customer-partial-paid-order.php` keep using their copy and do **not** get the new Payment Summary section. Document in release notes so store owners can re-copy if they want the new block.

## Notes

- The `class_exists('AngellEYE_PPCP_Partial_Payment_Data', false)` guard uses strict `false` so it won't trigger autoloaders during the check.
- The helper is **stateless and static** — safe to call from any context (not just email rendering). Callable from admin tooling, reporting dashboards, or future features that need the same capture summary.
- Extraction location `ppcp-gateway/includes/` matches the existing file convention (`class-angelleye-session-manager.php`, `ae-ppcp-constants.php`, etc.).
