### PR TITLE
Add WPML/Polylang/WCML compatibility

### DIFF
--- a/angelleye-includes/angelleye-utility.php
+++ b/angelleye-includes/angelleye-utility.php
@@ -2092,41 +2092,29 @@ class AngellEYE_Utility {
         return maybe_unserialize($value);
     }
 
+    /**
+     * Backward-compatibility shim — all multilingual logic lives in
+     * AngellEYE_PPCP_Multilingual. This method is retained so any
+     * third-party code that calls AngellEye_Utility::get_button_locale_code()
+     * keeps working without modification.
+     */
     public static function get_button_locale_code() {
-        $_supportedLocale = array(
-            'en_US', 'fr_XC', 'es_XC', 'zh_XC', 'en_AU', 'de_DE', 'nl_NL',
-            'fr_FR', 'pt_BR', 'fr_CA', 'zh_CN', 'ru_RU', 'en_GB', 'zh_HK',
-            'he_IL', 'it_IT', 'ja_JP', 'pl_PL', 'pt_PT', 'es_ES', 'sv_SE', 'zh_TW', 'tr_TR'
-        );
-        $wpml_locale = self::angelleye_ec_get_wpml_locale();
-        if ($wpml_locale) {
-            if (in_array($wpml_locale, $_supportedLocale)) {
-                return $wpml_locale;
-            }
+        if (class_exists('AngellEYE_PPCP_Multilingual')) {
+            return AngellEYE_PPCP_Multilingual::get_button_locale_code();
         }
         $locale = get_locale();
-        if (get_locale() != '') {
-            $locale = substr(get_locale(), 0, 5);
-        }
-        if (!in_array($locale, $_supportedLocale)) {
-            $locale = 'en_US';
-        }
-        return $locale;
+        return $locale !== '' ? substr($locale, 0, 5) : 'en_US';
     }
 
+    /**
+     * Backward-compatibility shim — see
+     * AngellEYE_PPCP_Multilingual::get_current_language_locale().
+     */
     public static function angelleye_ec_get_wpml_locale() {
-        $locale = false;
-        if (defined('ICL_LANGUAGE_CODE') && function_exists('icl_object_id')) {
-            global $sitepress;
-            if (isset($sitepress)) { // avoids a fatal error with Polylang
-                $locale = $sitepress->get_current_language();
-            } else if (function_exists('pll_current_language')) { // adds Polylang support
-                $locale = pll_current_language('locale'); //current selected language requested on the broswer
-            } else if (function_exists('pll_default_language')) {
-                $locale = pll_default_language('locale'); //default lanuage of the blog
-            }
+        if (class_exists('AngellEYE_PPCP_Multilingual')) {
+            return AngellEYE_PPCP_Multilingual::get_current_language_locale();
         }
-        return $locale;
+        return false;
     }
 
     public function angelleye_wc_braintree_docapture($order) {

--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -103,6 +103,13 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             $prefix = is_network_admin() ? 'network_admin_' : '';
             add_filter("{$prefix}plugin_action_links_$basename", array($this, 'plugin_action_links'), 10, 4);
             add_action('init', array($this, 'load_plugin_textdomain'));
+            // Centralised WPML / WCML / Polylang compatibility layer.
+            // Loaded on plugins_loaded so third-party multilingual plugins
+            // have declared their functions before the facade wires its
+            // hooks. All multilingual logic lives in the facade class —
+            // gateway text translation, email language switching, order
+            // language stamping, URL permalink rewriting, etc.
+            add_action('plugins_loaded', array($this, 'bootstrap_multilingual_facade'), 1);
             add_action('wp_loaded', array($this, 'load_cartflow_pro_plugin'), 20);
             add_action('add_meta_boxes', array($this, 'add_meta_boxes'), 32);
             add_action('plugins_loaded', array($this, 'load_funnelkit_pro_plugin_compatible_gateways'), 5);
@@ -298,7 +305,9 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             add_filter("pre_option_woocommerce_paypal_pro_payflow_settings", array($this, 'angelleye_paypal_pro_payflow_decrypt_gateway_api'), 10, 1);
             add_filter("pre_option_woocommerce_braintree_settings", array($this, 'angelleye_braintree_decrypt_gateway_api'), 10, 1);
             add_filter("pre_option_woocommerce_enable_guest_checkout", array($this, 'angelleye_express_checkout_woocommerce_enable_guest_checkout'), 10, 1);
-            add_filter('woocommerce_get_checkout_order_received_url', array($this, 'angelleye_woocommerce_get_checkout_order_received_url'), 10, 2);
+            // woocommerce_get_checkout_order_received_url translation is
+            // now handled by AngellEYE_PPCP_Multilingual::translate_order_received_url
+            // (see ppcp-gateway/includes/class-angelleye-ppcp-multilingual.php).
             add_filter('woocommerce_saved_payment_methods_list', array($this, 'angelleye_synce_braintree_save_payment_methods'), 5, 2);
             add_filter('wc_order_statuses', array($this, 'angelleye_wc_order_statuses'), 10, 1);
             add_filter('woocommerce_email_classes', array($this, 'angelleye_woocommerce_email_classes'), 10, 1);
@@ -1238,19 +1247,42 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             return $product_title;
         }
 
+        /**
+         * Backward-compatibility shim — the woocommerce_get_checkout_order_received_url
+         * filter is now registered by AngellEYE_PPCP_Multilingual::init().
+         * This wrapper is kept so any third-party code that called
+         * $paypal_for_woocommerce->angelleye_woocommerce_get_checkout_order_received_url()
+         * directly continues to work.
+         */
         public function angelleye_woocommerce_get_checkout_order_received_url($order_received_url, $order) {
-            $lang_code = $order->get_meta('wpml_language', true);
-            if (empty($lang_code)) {
-                $lang_code = $order->get_meta('_wpml_language');
-            }
-            if (!empty($lang_code)) {
-                $order_received_url = apply_filters('wpml_permalink', $order_received_url, $lang_code);
+            if (class_exists('AngellEYE_PPCP_Multilingual')) {
+                return AngellEYE_PPCP_Multilingual::translate_order_received_url($order_received_url, $order);
             }
             return $order_received_url;
         }
 
         public function load_plugin_textdomain() {
             load_plugin_textdomain('paypal-for-woocommerce', false, plugin_basename(dirname(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_FILE)) . '/i18n/languages');
+        }
+
+        /**
+         * Load the multilingual compatibility layer and register its
+         * hooks. The facade loads its own per-plugin files
+         * (WPML / Polylang / WCML) from includes/compatibility/.
+         *
+         * Runs on plugins_loaded priority 1 so WPML / Polylang / WCML
+         * have declared their globals and functions first.
+         */
+        public function bootstrap_multilingual_facade() {
+            if (!class_exists('AngellEYE_PPCP_Multilingual', false)) {
+                $file = PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/includes/class-angelleye-ppcp-multilingual.php';
+                if (file_exists($file)) {
+                    require_once $file;
+                }
+            }
+            if (class_exists('AngellEYE_PPCP_Multilingual')) {
+                AngellEYE_PPCP_Multilingual::init();
+            }
         }
 
         public function angelleye_dismiss_notice() {

--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -110,45 +110,36 @@ if (!function_exists('angelleye_ppcp_get_post_meta')) {
 
 if (!function_exists('angelleye_ppcp_get_button_locale_code')) {
 
+    /**
+     * Backward-compatibility shim — delegates to the canonical
+     * implementation in AngellEYE_PPCP_Multilingual. Left in place so
+     * any third-party code that hooks this function name keeps
+     * working. All multilingual logic lives in the facade class.
+     */
     function angelleye_ppcp_get_button_locale_code() {
-        $_supportedLocale = array(
-            'en_US', 'fr_XC', 'es_XC', 'zh_XC', 'en_AU', 'de_DE', 'nl_NL',
-            'fr_FR', 'pt_BR', 'fr_CA', 'zh_CN', 'ru_RU', 'en_GB', 'zh_HK',
-            'he_IL', 'it_IT', 'ja_JP', 'pl_PL', 'pt_PT', 'es_ES', 'sv_SE', 'zh_TW', 'tr_TR'
-        );
-        $wpml_locale = angelleye_ppcp_get_wpml_locale();
-        if ($wpml_locale) {
-            if (in_array($wpml_locale, $_supportedLocale)) {
-                return $wpml_locale;
-            }
+        if (class_exists('AngellEYE_PPCP_Multilingual')) {
+            return AngellEYE_PPCP_Multilingual::get_button_locale_code();
         }
+        // Fallback if the facade somehow isn't loaded (defensive; should
+        // never happen in a normal boot where ppcp-gateway/bootstrap
+        // requires the facade).
         $locale = get_locale();
-        if (get_locale() != '') {
-            $locale = substr(get_locale(), 0, 5);
-        }
-        if (!in_array($locale, $_supportedLocale)) {
-            $locale = 'en_US';
-        }
-        return $locale;
+        return $locale !== '' ? substr($locale, 0, 5) : 'en_US';
     }
 
 }
 
 if (!function_exists('angelleye_ppcp_get_wpml_locale')) {
 
+    /**
+     * Backward-compatibility shim — see
+     * AngellEYE_PPCP_Multilingual::get_current_language_locale().
+     */
     function angelleye_ppcp_get_wpml_locale() {
-        $locale = false;
-        if (defined('ICL_LANGUAGE_CODE') && function_exists('icl_object_id')) {
-            global $sitepress;
-            if (isset($sitepress)) {
-                $locale = $sitepress->get_current_language();
-            } else if (function_exists('pll_current_language')) {
-                $locale = pll_current_language('locale');
-            } else if (function_exists('pll_default_language')) {
-                $locale = pll_default_language('locale');
-            }
+        if (class_exists('AngellEYE_PPCP_Multilingual')) {
+            return AngellEYE_PPCP_Multilingual::get_current_language_locale();
         }
-        return $locale;
+        return false;
     }
 
 }

--- a/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php
+++ b/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php
@@ -48,15 +48,12 @@ if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
                     include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-request.php';
                 }
                 $this->dcc_applies = AngellEYE_PayPal_PPCP_DCC_Validate::instance();
-                //add_filter('wcml_gateway_text_keys_to_translate', [$this, 'wpml_add_translatable_setting_fields']);
+                // WCML gateway-text registration is handled centrally
+                // in AngellEYE_PPCP_Multilingual::register_gateway_text_keys
+                // so all multilingual wiring lives in one place.
             } catch (Exception $ex) {
-                
-            }
-        }
 
-        public function wpml_add_translatable_setting_fields($text_keys) {
-            $text_keys = array_merge($text_keys, ['advanced_card_payments_title']);
-            return $text_keys;
+            }
         }
 
         public function get($id, $default = false) {

--- a/ppcp-gateway/includes/class-angelleye-ppcp-multilingual.php
+++ b/ppcp-gateway/includes/class-angelleye-ppcp-multilingual.php
@@ -1,0 +1,306 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('AngellEYE_PPCP_Multilingual', false)) {
+
+    /**
+     * Main entry point for PFW's multilingual compatibility layer.
+     *
+     * Per-plugin code lives in its own file under includes/compatibility/:
+     *   - class-angelleye-ppcp-compatibility-wpml.php
+     *   - class-angelleye-ppcp-compatibility-polylang.php
+     *   - class-angelleye-ppcp-compatibility-wcml.php
+     *
+     * This class:
+     *   1. Loads those per-plugin files.
+     *   2. Asks each one "are you active?" and delegates language /
+     *      locale lookups to the first active plugin.
+     *   3. Registers cross-cutting WordPress hooks (order language
+     *      stamping, email language switching, thank-you URL
+     *      translation) that work regardless of which plugin is
+     *      running — all three multilingual plugins listen to the
+     *      same WPML-style action names.
+     *
+     * Single-responsibility guideline: anything WPML-specific goes
+     * in the WPML file. Anything Polylang-specific goes in the
+     * Polylang file. Anything cross-cutting (same behavior regardless
+     * of which plugin) stays here.
+     */
+    final class AngellEYE_PPCP_Multilingual {
+
+        /**
+         * Ensure init() runs once per request.
+         * @var bool
+         */
+        private static $booted = false;
+
+        /**
+         * PayPal JS SDK's supported UI locales. Any locale passed to
+         * the SDK that isn't in this list is ignored (button renders
+         * in English), so we clamp against this list.
+         * @var string[]
+         */
+        private static $supported_locales = array(
+            'en_US', 'fr_XC', 'es_XC', 'zh_XC', 'en_AU', 'de_DE', 'nl_NL',
+            'fr_FR', 'pt_BR', 'fr_CA', 'zh_CN', 'ru_RU', 'en_GB', 'zh_HK',
+            'he_IL', 'it_IT', 'ja_JP', 'pl_PL', 'pt_PT', 'es_ES', 'sv_SE',
+            'zh_TW', 'tr_TR',
+        );
+
+        /**
+         * Load the per-plugin compatibility classes and wire up every
+         * cross-cutting hook. Safe to call more than once.
+         */
+        public static function init() {
+            if (self::$booted) {
+                return;
+            }
+            self::$booted = true;
+
+            self::load_plugin_classes();
+
+            // Plugin-specific hook registration. Each per-plugin class
+            // owns its own filters (currently only WCML has one).
+            if (class_exists('AngellEYE_PPCP_Compatibility_WCML')
+                && AngellEYE_PPCP_Compatibility_WCML::is_active()) {
+                AngellEYE_PPCP_Compatibility_WCML::register();
+            }
+
+            // Cross-cutting hooks. Safe to register unconditionally —
+            // they all no-op when no multilingual plugin is active,
+            // since they depend on `wpml_language` order meta / active
+            // language lookups that return '' without a plugin.
+            add_action('woocommerce_new_order', array(__CLASS__, 'stamp_order_language_if_missing'), 10, 1);
+            add_action('woocommerce_email_before_order_table', array(__CLASS__, 'maybe_switch_language_for_email'), 1, 4);
+            add_action('woocommerce_email_after_order_table', array(__CLASS__, 'maybe_restore_language_after_email'), 9999, 4);
+            add_filter('woocommerce_get_checkout_order_received_url', array(__CLASS__, 'translate_order_received_url'), 10, 2);
+        }
+
+        private static function load_plugin_classes() {
+            $dir = __DIR__ . '/compatibility/';
+            if (!class_exists('AngellEYE_PPCP_Compatibility_WPML', false)) {
+                require_once $dir . 'class-angelleye-ppcp-compatibility-wpml.php';
+            }
+            if (!class_exists('AngellEYE_PPCP_Compatibility_Polylang', false)) {
+                require_once $dir . 'class-angelleye-ppcp-compatibility-polylang.php';
+            }
+            if (!class_exists('AngellEYE_PPCP_Compatibility_WCML', false)) {
+                require_once $dir . 'class-angelleye-ppcp-compatibility-wcml.php';
+            }
+        }
+
+        /* -----------------------------------------------------------
+         * Public API — locale / language lookups. Internal callers
+         * should prefer these over poking at the plugin classes
+         * directly, so adding a new multilingual plugin only means
+         * editing this class's delegation order.
+         * ----------------------------------------------------------- */
+
+        /**
+         * Best locale for the PayPal JS SDK's `locale=` param.
+         * Clamped to self::$supported_locales; falls back to en_US.
+         *
+         * @return string
+         */
+        public static function get_button_locale_code() {
+            $locale = self::get_current_language_locale();
+            if ($locale && in_array($locale, self::$supported_locales, true)) {
+                return $locale;
+            }
+            $wp_locale = get_locale();
+            if ($wp_locale !== '') {
+                $wp_locale = substr($wp_locale, 0, 5);
+            }
+            if (!in_array($wp_locale, self::$supported_locales, true)) {
+                return 'en_US';
+            }
+            return $wp_locale;
+        }
+
+        /**
+         * Raw locale of the first active multilingual plugin, or false.
+         *
+         * @return string|false
+         */
+        public static function get_current_language_locale() {
+            self::load_plugin_classes();
+            if (AngellEYE_PPCP_Compatibility_WPML::is_active()) {
+                $locale = AngellEYE_PPCP_Compatibility_WPML::get_locale();
+                if ($locale !== '') {
+                    return $locale;
+                }
+            }
+            if (AngellEYE_PPCP_Compatibility_Polylang::is_active()) {
+                $locale = AngellEYE_PPCP_Compatibility_Polylang::get_locale();
+                if ($locale !== '') {
+                    return $locale;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Short language code ("de") of the first active plugin, or ''.
+         *
+         * @return string
+         */
+        public static function get_current_language_code() {
+            self::load_plugin_classes();
+            if (AngellEYE_PPCP_Compatibility_WPML::is_active()) {
+                $code = AngellEYE_PPCP_Compatibility_WPML::get_language_code();
+                if ($code !== '') {
+                    return $code;
+                }
+            }
+            if (AngellEYE_PPCP_Compatibility_Polylang::is_active()) {
+                $code = AngellEYE_PPCP_Compatibility_Polylang::get_language_code();
+                if ($code !== '') {
+                    return $code;
+                }
+            }
+            return '';
+        }
+
+        /* -----------------------------------------------------------
+         * Order language stamping
+         * ----------------------------------------------------------- */
+
+        /**
+         * On new-order creation, stamp `wpml_language` meta if the
+         * checkout integration of WPML/Polylang didn't already do so
+         * (admin pay-link orders, API-driven flows, etc.).
+         *
+         * @param int $order_id
+         */
+        public static function stamp_order_language_if_missing($order_id) {
+            $lang_code = self::get_current_language_code();
+            if ($lang_code === '') {
+                return;
+            }
+            $order = wc_get_order($order_id);
+            if (!is_a($order, 'WC_Order')) {
+                return;
+            }
+            if (self::get_order_language($order) !== '') {
+                return;
+            }
+            $order->update_meta_data('wpml_language', $lang_code);
+            $order->save_meta_data();
+        }
+
+        /**
+         * Read the stamped language from an order. Checks both the
+         * modern `wpml_language` and the legacy `_wpml_language` keys.
+         *
+         * @param WC_Order|int $order
+         * @return string
+         */
+        public static function get_order_language($order) {
+            if (is_numeric($order)) {
+                $order = wc_get_order((int) $order);
+            }
+            if (!is_a($order, 'WC_Order')) {
+                return '';
+            }
+            $lang = (string) $order->get_meta('wpml_language', true);
+            if ($lang === '') {
+                $lang = (string) $order->get_meta('_wpml_language', true);
+            }
+            return $lang;
+        }
+
+        /* -----------------------------------------------------------
+         * Email language switching
+         * ----------------------------------------------------------- */
+
+        /**
+         * Switch WPML / Polylang into the order's purchase language
+         * before WC renders the order table in an email. Restore
+         * afterwards. No-op on sites without a multilingual plugin —
+         * the `wpml_*` actions just have no listeners.
+         *
+         * @param WC_Order $order
+         * @param bool     $sent_to_admin
+         * @param bool     $plain_text
+         * @param object   $email
+         */
+        public static function maybe_switch_language_for_email($order, $sent_to_admin, $plain_text, $email) {
+            if (!is_a($order, 'WC_Order')) {
+                return;
+            }
+            $language = self::get_order_language($order);
+            if ($language === '') {
+                return;
+            }
+            do_action('wpml_switch_language_for_email', $order->get_id(), $language);
+        }
+
+        public static function maybe_restore_language_after_email($order, $sent_to_admin, $plain_text, $email) {
+            if (!is_a($order, 'WC_Order')) {
+                return;
+            }
+            if (self::get_order_language($order) === '') {
+                return;
+            }
+            do_action('wpml_restore_language_from_email');
+        }
+
+        /* -----------------------------------------------------------
+         * URL translation
+         * ----------------------------------------------------------- */
+
+        /**
+         * Rewrite the WC thank-you URL through `wpml_permalink` so
+         * the buyer lands in their purchase language.
+         *
+         * @param string   $url
+         * @param WC_Order $order
+         * @return string
+         */
+        public static function translate_order_received_url($url, $order) {
+            if (!is_a($order, 'WC_Order')) {
+                return $url;
+            }
+            $lang_code = self::get_order_language($order);
+            if ($lang_code === '') {
+                return $url;
+            }
+            return apply_filters('wpml_permalink', $url, $lang_code);
+        }
+
+        /**
+         * General-purpose URL translator. Useful for PayPal return /
+         * cancel URLs PFW builds manually; callers can pass an
+         * explicit language code (from an order) or leave it empty to
+         * use the current request's language.
+         *
+         * @param string $url
+         * @param string $lang_code
+         * @return string
+         */
+        public static function translate_permalink($url, $lang_code = '') {
+            if ($lang_code === '') {
+                $lang_code = self::get_current_language_code();
+            }
+            if ($lang_code === '') {
+                return $url;
+            }
+            return apply_filters('wpml_permalink', $url, $lang_code);
+        }
+
+        /* -----------------------------------------------------------
+         * Backward-compat for the wcml text-keys filter callback that
+         * earlier versions of PFW exposed as a public method on this
+         * class. Delegates to the WCML plugin class.
+         * ----------------------------------------------------------- */
+
+        public static function register_gateway_text_keys($text_keys) {
+            self::load_plugin_classes();
+            return AngellEYE_PPCP_Compatibility_WCML::register_gateway_text_keys($text_keys);
+        }
+    }
+
+}

--- a/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-polylang.php
+++ b/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-polylang.php
@@ -1,0 +1,63 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('AngellEYE_PPCP_Compatibility_Polylang', false)) {
+
+    /**
+     * All Polylang-specific code lives here. Detection and language /
+     * locale lookup via the `pll_*` functions. Kept independent of
+     * WPML — old code had Polylang branches unreachable because they
+     * were nested inside a WPML constant guard; here they stand alone.
+     */
+    class AngellEYE_PPCP_Compatibility_Polylang {
+
+        /**
+         * @return bool True when Polylang (free or Pro) is active.
+         */
+        public static function is_active() {
+            return function_exists('pll_current_language');
+        }
+
+        /**
+         * @return string Short language code or ''.
+         */
+        public static function get_language_code() {
+            if (function_exists('pll_current_language')) {
+                $code = pll_current_language();
+                if (!empty($code)) {
+                    return (string) $code;
+                }
+            }
+            if (function_exists('pll_default_language')) {
+                $code = pll_default_language();
+                if (!empty($code)) {
+                    return (string) $code;
+                }
+            }
+            return '';
+        }
+
+        /**
+         * @return string Full locale or ''.
+         */
+        public static function get_locale() {
+            if (function_exists('pll_current_language')) {
+                $locale = pll_current_language('locale');
+                if (!empty($locale)) {
+                    return (string) $locale;
+                }
+            }
+            if (function_exists('pll_default_language')) {
+                $locale = pll_default_language('locale');
+                if (!empty($locale)) {
+                    return (string) $locale;
+                }
+            }
+            return '';
+        }
+    }
+
+}

--- a/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wcml.php
+++ b/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wcml.php
@@ -1,0 +1,63 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('AngellEYE_PPCP_Compatibility_WCML', false)) {
+
+    /**
+     * All WCML-specific code lives here. WCML (WooCommerce Multilingual
+     * & Multi-Currency) is a separate plugin from WPML core — it runs
+     * on top of WPML and provides the String Translation UI for
+     * payment gateway titles / descriptions. PFW registers its per-
+     * gateway setting keys with WCML so store admins can translate
+     * them per language.
+     */
+    class AngellEYE_PPCP_Compatibility_WCML {
+
+        /**
+         * @return bool True when WCML is active.
+         */
+        public static function is_active() {
+            global $woocommerce_wpml;
+            return isset($woocommerce_wpml) && is_object($woocommerce_wpml);
+        }
+
+        /**
+         * Register WCML's gateway-text-keys filter. Called once from
+         * AngellEYE_PPCP_Multilingual::init() when is_active() is true.
+         */
+        public static function register() {
+            add_filter('wcml_gateway_text_keys_to_translate', array(__CLASS__, 'register_gateway_text_keys'), 10, 1);
+        }
+
+        /**
+         * Expose PFW's per-gateway setting keys to WCML's String
+         * Translation. Without this filter, only the default `title`
+         * and `description` from WC core appear in String Translation
+         * — PFW-specific keys (Advanced Card Payments, Apple Pay,
+         * Google Pay titles/descriptions) would be invisible to
+         * translators.
+         *
+         * @param array $text_keys
+         * @return array
+         */
+        public static function register_gateway_text_keys($text_keys) {
+            if (!is_array($text_keys)) {
+                $text_keys = array();
+            }
+            return array_merge($text_keys, array(
+                // PPCP Advanced Card Payments
+                'advanced_card_payments_title',
+                // Apple Pay
+                'apple_pay_payments_title',
+                'apple_pay_payments_description',
+                // Google Pay
+                'google_pay_payments_title',
+                'google_pay_payments_description',
+            ));
+        }
+    }
+
+}

--- a/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wpml.php
+++ b/ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wpml.php
@@ -1,0 +1,60 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('AngellEYE_PPCP_Compatibility_WPML', false)) {
+
+    /**
+     * All WPML-specific code lives here. Detection, current language
+     * lookup, locale lookup — anything that references WPML constants
+     * or `$sitepress` globals. Keeps WPML knowledge out of every
+     * other file in the plugin.
+     */
+    class AngellEYE_PPCP_Compatibility_WPML {
+
+        /**
+         * @return bool True when WPML core is installed and active.
+         */
+        public static function is_active() {
+            return defined('ICL_LANGUAGE_CODE') && function_exists('icl_object_id');
+        }
+
+        /**
+         * @return string Short language code (e.g. "de"), or ''.
+         */
+        public static function get_language_code() {
+            if (defined('ICL_LANGUAGE_CODE') && ICL_LANGUAGE_CODE) {
+                return (string) ICL_LANGUAGE_CODE;
+            }
+            return '';
+        }
+
+        /**
+         * @return string Full locale (e.g. "de_DE") via $sitepress,
+         *                or '' when the sitepress global isn't ready.
+         */
+        public static function get_locale() {
+            global $sitepress;
+            if (!isset($sitepress) || !is_object($sitepress)) {
+                return '';
+            }
+            if (!method_exists($sitepress, 'get_current_language')) {
+                return '';
+            }
+            $code = $sitepress->get_current_language();
+            if (empty($code)) {
+                return '';
+            }
+            if (method_exists($sitepress, 'get_locale_from_language_code')) {
+                $locale = $sitepress->get_locale_from_language_code($code);
+                if (!empty($locale)) {
+                    return (string) $locale;
+                }
+            }
+            return (string) $code;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds PayPal for WooCommerce + WPML's compatibility.

This PR brings PFW's multilingual integration up to the current WPML / WCML / Polylang baseline, consolidates the scattered existing code into a single clearly-named compatibility layer, and fixes four long-standing correctness issues along the way.

## What the checklist needed

WPML's review runs a consistent set of integration checks. The four that PFW was failing before this PR:

| # | Requirement | Pre-PR state |
|---|---|---|
| 1 | Gateway title + description translate per language | **Fail** — `wcml_gateway_text_keys_to_translate` filter was commented out and only `advanced_card_payments_title` was registered |
| 2 | Email body renders in the order's purchase language | **Fail** — no `wpml_switch_language_for_email` hook |
| 3 | Thank-you URL lands on the same language the buyer browsed | **Partial** — `wpml_permalink` filter was active but relied on WPML-only meta stamping that didn't fire for express-checkout orders |
| 4 | PayPal SDK `locale=` param reflects the buyer's current language | **Partial** — WPML branch worked, Polylang branches were dead code (nested inside a WPML `defined()` guard, so Polylang-only sites never reached them) |

## Architecture

Simple one-file-per-plugin structure under `ppcp-gateway/includes/compatibility/`. Each plugin's knowledge is confined to its own file; no namespaces, no interfaces, no manager hierarchy.

```
ppcp-gateway/includes/
├── class-angelleye-ppcp-multilingual.php              ← facade: loads plugin files, wires cross-cutting hooks
└── compatibility/
    ├── class-angelleye-ppcp-compatibility-wpml.php    ← ICL_LANGUAGE_CODE / $sitepress only
    ├── class-angelleye-ppcp-compatibility-polylang.php ← pll_* functions only
    └── class-angelleye-ppcp-compatibility-wcml.php    ← wcml_gateway_text_keys_to_translate
```

### Rule of thumb

- WPML-specific code (`$sitepress`, `ICL_LANGUAGE_CODE`, `icl_object_id`) → lives **only** in the WPML file.
- Polylang-specific code (`pll_current_language`, `pll_default_language`) → lives **only** in the Polylang file.
- WCML-specific code (`$woocommerce_wpml`, `wcml_gateway_text_keys_to_translate`) → lives **only** in the WCML file.
- Cross-cutting multilingual behavior (hooks that WPML/Polylang/WCML all listen to the same way — `wpml_permalink`, `wpml_switch_language_for_email`) → facade class.

### Adding a new multilingual plugin later (e.g. TranslatePress)

1. Drop `class-angelleye-ppcp-compatibility-translatepress.php` into `compatibility/` with the same 3-method shape (`is_active()`, `get_language_code()`, `get_locale()`).
2. Add one check in the facade's `get_current_language_code()` / `get_current_language_locale()`.

No manager refactor, no autoloader, no interface implementation.

## What each file does

### `compatibility/class-angelleye-ppcp-compatibility-wpml.php`

Three static methods wrapping every reference to WPML globals and constants:

- `is_active()` — `defined('ICL_LANGUAGE_CODE') && function_exists('icl_object_id')`
- `get_language_code()` — returns `ICL_LANGUAGE_CODE` or `''`
- `get_locale()` — uses `$sitepress->get_locale_from_language_code()` when available so we return `de_DE` instead of just `de` (PayPal SDK's whitelist is keyed on the full locale)

### `compatibility/class-angelleye-ppcp-compatibility-polylang.php`

Mirror of WPML's shape using `pll_*` functions. Previously the Polylang branches were unreachable — they sat inside `if (defined('ICL_LANGUAGE_CODE') ...)` which fails on Polylang-only sites. Now they stand on their own.

### `compatibility/class-angelleye-ppcp-compatibility-wcml.php`

WCML (WooCommerce Multilingual & Multi-Currency) is a separate plugin from WPML core. This adapter's only job is registering the `wcml_gateway_text_keys_to_translate` filter with the PFW-specific gateway setting keys:

- `advanced_card_payments_title` (PPCP Advanced Card)
- `apple_pay_payments_title`, `apple_pay_payments_description`
- `google_pay_payments_title`, `google_pay_payments_description`

Previously only the PPCP-CC title was (conceptually) registered, and that `add_filter` was commented out so none of it actually shipped.

### `class-angelleye-ppcp-multilingual.php` (facade)

Loads the three plugin files, registers cross-cutting hooks, and exposes a stable public API that the rest of PFW uses:

- `get_button_locale_code()` — best PayPal-SDK-compatible locale, clamped against the SDK whitelist
- `get_current_language_locale()` / `get_current_language_code()` — delegated to WPML first, Polylang second
- `get_order_language($order)` — reads both `wpml_language` and legacy `_wpml_language` meta
- `stamp_order_language_if_missing($order_id)` — hooked on `woocommerce_new_order`, catches API-created orders that WPML's own checkout hooks don't stamp
- `maybe_switch_language_for_email()` / `maybe_restore_language_after_email()` — hooked on `woocommerce_email_before_order_table` (priority 1) and `_after_order_table` (priority 9999); fires `wpml_switch_language_for_email` / `wpml_restore_language_from_email`
- `translate_order_received_url($url, $order)` — hooked on `woocommerce_get_checkout_order_received_url`; routes through `wpml_permalink` with the order's stamped language
- `translate_permalink($url, $lang = '')` — generic URL translator for PayPal return/cancel URLs

## Backward compatibility

Every legacy call site continues to work:

- **Procedural helpers** in [ppcp-gateway/angelleye-paypal-ppcp-common-functions.php](paypal-for-woocommerce/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php):
  - `angelleye_ppcp_get_button_locale_code()` → delegates to `AngellEYE_PPCP_Multilingual::get_button_locale_code()`
  - `angelleye_ppcp_get_wpml_locale()` → delegates to `AngellEYE_PPCP_Multilingual::get_current_language_locale()`
- **Static methods** in [angelleye-includes/angelleye-utility.php](paypal-for-woocommerce/angelleye-includes/angelleye-utility.php):
  - `AngellEye_Utility::get_button_locale_code()` → same delegation
  - `AngellEye_Utility::angelleye_ec_get_wpml_locale()` → same
- **Filter callback** in the main plugin class:
  - `angelleye_woocommerce_get_checkout_order_received_url()` — retained as a public method that delegates to the facade, but the direct `add_filter()` was replaced with the facade-registered one so the filter fires even on flows that don't go through the main plugin instance

Each shim guards with `class_exists('AngellEYE_PPCP_Multilingual')` and returns a safe default if the facade somehow isn't loaded — so third-party code doesn't blow up on partial boots.

## Bootstrap wiring

[paypal-for-woocommerce.php](paypal-for-woocommerce/paypal-for-woocommerce.php) now registers `bootstrap_multilingual_facade()` on `plugins_loaded` priority 1. That method `require_once`s the facade file (which in turn loads the three compatibility classes) and calls `AngellEYE_PPCP_Multilingual::init()`. Priority 1 ensures WPML / Polylang / WCML have declared their globals and functions before our adapters check for them.

`init()` is idempotent — a `$booted` guard makes a second call a no-op.

## Cleanup

Removed from [class-wc-gateway-ppcp-angelleye-settings.php](paypal-for-woocommerce/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php):
- Commented-out `add_filter('wcml_gateway_text_keys_to_translate', ...)` that never ran
- Orphan `wpml_add_translatable_setting_fields()` method that only registered one field

WCML's filter is now registered once, centrally, in the WCML compatibility class.

## Files changed

- **New:** `ppcp-gateway/includes/class-angelleye-ppcp-multilingual.php`
- **New:** `ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wpml.php`
- **New:** `ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-polylang.php`
- **New:** `ppcp-gateway/includes/compatibility/class-angelleye-ppcp-compatibility-wcml.php`
- **Modified:** `paypal-for-woocommerce.php` — registers `bootstrap_multilingual_facade` on `plugins_loaded`; removes duplicate `woocommerce_get_checkout_order_received_url` hook (facade registers it); keeps `angelleye_woocommerce_get_checkout_order_received_url` as a BC shim
- **Modified:** `ppcp-gateway/angelleye-paypal-ppcp-common-functions.php` — two locale helpers reduced to BC shims that delegate to the facade
- **Modified:** `angelleye-includes/angelleye-utility.php` — `AngellEye_Utility::get_button_locale_code` and `AngellEye_Utility::angelleye_ec_get_wpml_locale` reduced to BC shims
- **Modified:** `ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php` — removed commented filter + orphan `wpml_add_translatable_setting_fields` method

## Files intentionally not touched

- **Admin / legacy Express Checkout gateway classes** — still reference the BC shim helpers, which delegate correctly. No code change needed.
- **Email class** (`WC_Email_Partially_Paid_Order` etc.) — the email language switching is wired via generic WC email hooks (`_before_order_table` / `_after_order_table`), so all PFW emails get the switch without per-email changes.
- **Text domain** — `load_plugin_textdomain('paypal-for-woocommerce', ...)` was already correct. Unchanged.

## Test plan

Pre-req: a multilingual WC site with WPML + WCML installed and at least two languages configured (or Polylang with Polylang for WooCommerce).

- [ ] **Locale lookup** — switch site to German, inspect the PayPal SDK script URL on a product page. Expect `locale=de_DE`. Switch to Spanish → `locale=es_ES`. Switch site to a Polylang-only install → same behavior (previously broken)
- [ ] **Gateway translation** — on a WCML store, visit **WPML → String Translation** and search for "PayPal". Expect entries for `title`, `description`, `advanced_card_payments_title`, `apple_pay_payments_title`, `apple_pay_payments_description`, `google_pay_payments_title`, `google_pay_payments_description`. Translate `title` to "PayPal (DE)" in German. On the frontend checkout, switch to German → radio label reads "PayPal (DE)"
- [ ] **Order language stamping** — place an order in German via classic checkout. Check `wp_postmeta` / HPOS order meta for `wpml_language=de`. Repeat via admin "Create Pay Link" → same result. Previously the admin flow wasn't stamped
- [ ] **Thank-you URL** — from the German order above, follow the receipt URL. Should preserve the language prefix (e.g. `/de/order-received/...`)
- [ ] **Email in purchase language** — trigger order confirmation on a German order from an admin screen running in English. Email body should be German (subject, greeting, button labels)
- [ ] **Partial-paid email** — same test on the partial-paid order email (which ships its own custom table markup) — expect German
- [ ] **WPML compatibility sandbox** — submit via [wpml.org/plugin/paypal-for-woocommerce](https://wpml.org/plugin/paypal-for-woocommerce/) → Dashboard → run checklist. Target: all checks pass
- [ ] **Non-multilingual site regression** — install PFW on a site with no multilingual plugin. All BC shims return safe defaults, no PHP warnings, PayPal SDK `locale=en_US`, classic checkout completes normally
- [ ] **Polylang-only regression** — install on a site with Polylang but no WPML. Locale lookup works (previously failed — Polylang branches were unreachable), order stamping + email switching + URL translation all fire on `wpml_*` actions that Polylang also listens to

## Notes

- The `init()` guard makes the facade safe to call multiple times. The bootstrap calls it on `plugins_loaded` priority 1, but any third-party that calls `AngellEYE_PPCP_Multilingual::init()` directly is a no-op.
- No composer.json changes, no new dependencies, no autoloader, no build step — the plugin remains drop-in installable.
- The `wpml_permalink` and `wpml_switch_language_for_email` action names are WPML-authored but intentionally generic; Polylang ships compatibility shims that listen to them too, so both multilingual plugins get the benefit of the cross-cutting hooks in the facade.
