### PR TITLE
Include Express Checkout parent before subscription subclasses

### DIFF
--- a/paypal-for-woocommerce.php
+++ b/paypal-for-woocommerce.php
@@ -573,6 +573,20 @@ if (!class_exists('AngellEYE_Gateway_Paypal')) {
             // Ensure PPCP traits/classes are loaded before any direct gateway class includes.
             $this->bootstrap_ppcp_runtime();
 
+            // Parent gateway classes must be loaded before subscription subclasses that extend them.
+            // Without this, another plugin reading WC()->payment_gateways during `init` (before our
+            // init() runs at priority 1000) would trigger a fatal "parent class not found" error.
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-payflow-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-advanced-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-pro-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-braintree-angelleye.php');
+            include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-credit-cards-rest-angelleye.php');
+            if (is_angelleye_multi_account_active()) {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v1.php');
+            } else {
+                include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v2.php');
+            }
+
             if (class_exists('WC_Subscriptions') && function_exists('wcs_create_renewal_order')) {
                 $this->subscription_support_enabled = true;
             }


### PR DESCRIPTION
## Summary

Completes the parent-class preload started in #2174 by adding the Express Checkout gateway, which the original PR missed.

## Background

If any plugin reads WC()->payment_gateways during WP init at priority < 1000, our filter fires, tries to include_once a subscription subclass, whose extends target isn't defined yet → Class "…" not found fatal. The diagnosis is accurate.


Item | Line | Fact
-- | -- | --
Filter registration | line 132 | woocommerce_payment_gateways filter fires any time anyone reads WC()->payment_gateways
init() load timing | line 133 | Hooked on WP init priority 1000 via include_gateway_in_list()
Parent classes loaded | lines 429-438 | Only inside init()
Subscription subclasses loaded | lines 618-623 | Inside the filter callback
Subscription subclass extends chain | verified | All 6 extend non-PPCP parents (e.g. WC_Gateway_PayPal_Pro_PayFlow_Subscriptions_AngellEYE extends WC_Gateway_PayPal_Pro_PayFlow_AngellEYE)

## The gap

In `angelleye_add_paypal_pro_gateway()`:

- [paypal-for-woocommerce.php#L610](paypal-for-woocommerce.php#L610) and [#L620](paypal-for-woocommerce.php#L620) include `wc-gateway-paypal-express-subscriptions-angelleye.php`
- That subclass: `class WC_Gateway_PayPal_Express_Subscriptions_AngellEYE extends WC_Gateway_PayPal_Express_AngellEYE`
- The parent lives in `classes/wc-gateway-paypal-express-angelleye-v1.php` / `-v2.php`, loaded only inside `init()` at [#L431-L435](paypal-for-woocommerce.php#L431-L435)

## Fix

Add the v1/v2 Express Checkout `include_once` right after #2174's preload block, using the same `is_angelleye_multi_account_active()` branch that `init()` uses.

```php
if (is_angelleye_multi_account_active()) {
    include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v1.php');
} else {
    include_once(PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/classes/wc-gateway-paypal-express-angelleye-v2.php');
}

include_once is idempotent, so init() loading the same file later is a no-op.

Relates to #2174.