### PR TITLE
Fix save payment method option visibility on checkout page for non-vault enabled sellers

### DIFF
--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -896,13 +896,19 @@ if (!function_exists('angelleye_ppcp_is_store_api_request')) {
 if (!function_exists('angelleye_ppcp_is_save_payment_method')) {
 
     function angelleye_ppcp_is_save_payment_method($enable_tokenized_payments) {
+        // Safety net: never vault when the admin toggle is off, or when the PayPal
+        // merchant account doesn't actually have ADVANCED_VAULTING provisioned.
+        // This catches POST-checkbox tampering and filter-injected overrides.
+        if ($enable_tokenized_payments !== true || !angelleye_ppcp_is_vault_capability_available()) {
+            return apply_filters('angelleye_ppcp_is_save_payment_method', false);
+        }
         $is_enable = false;
         $new_payment_methods_to_check = [
             'wc-angelleye_ppcp-new-payment-method',
             'wc-angelleye_ppcp_cc-new-payment-method',
             'wc-angelleye_ppcp_apple_pay-new-payment-method'
         ];
-        if (angelleye_ppcp_is_cart_subscription() && $enable_tokenized_payments === true) {
+        if (angelleye_ppcp_is_cart_subscription()) {
             $is_enable = true;
         }
         foreach ($new_payment_methods_to_check as $item) {
@@ -914,9 +920,9 @@ if (!function_exists('angelleye_ppcp_is_save_payment_method')) {
         // When tokenization is enabled and request originates from product/cart page
         // (or checkout_top), the save-payment-method checkbox is not in the serialized
         // form data. Force vault so the token is stored with the order.
-        if ( ! $is_enable && $enable_tokenized_payments === true ) {
-            $request_from = isset( $_GET['from'] ) ? sanitize_text_field( $_GET['from'] ) : '';
-            if ( ! in_array( $request_from, array( 'checkout', 'pay_page' ), true ) ) {
+        if (!$is_enable) {
+            $request_from = isset($_GET['from']) ? sanitize_text_field($_GET['from']) : '';
+            if (!in_array($request_from, array('checkout', 'pay_page'), true)) {
                 $is_enable = true;
             }
         }
@@ -1049,6 +1055,53 @@ if (!function_exists('angelleye_is_vaulting_enable')) {
             }
         }
         return false;
+    }
+
+}
+
+if (!function_exists('angelleye_ppcp_is_vault_capability_available')) {
+
+    /**
+     * Returns whether ADVANCED_VAULTING is active on the connected PayPal merchant.
+     *
+     * Layered caching, cheapest-first:
+     *   1. Per-request static cache — repeated calls in one request cost nothing.
+     *   2. `ae_seller_onboarding_status` transient (1-day TTL) — shared across
+     *      requests; populated by admin settings / here on first miss.
+     *   3. PayPal Partner API — called only when the transient is missing or
+     *      expired, and the result re-primes the transient for the next day.
+     *
+     * This keeps frontend page loads free of API calls in steady state while
+     * still recovering automatically after the cache expires.
+     */
+    function angelleye_ppcp_is_vault_capability_available() {
+        static $cached = null;
+        if ($cached !== null) {
+            return $cached;
+        }
+        // Fail closed if invoked before plugin bootstrap defines paths/constants
+        // (e.g. another plugin instantiates the gateway unusually early).
+        if (!defined('PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR')) {
+            return $cached = false;
+        }
+        if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
+            include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php';
+        }
+        $settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
+        $is_sandbox = 'yes' === $settings->get('testmode', 'no');
+        $merchant_id = $settings->get($is_sandbox ? 'sandbox_merchant_id' : 'live_merchant_id', '');
+        if (empty($merchant_id)) {
+            return $cached = false;
+        }
+        if (!class_exists('AngellEYE_PayPal_PPCP_Seller_Onboarding')) {
+            include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-seller-onboarding.php';
+        }
+        $result = AngellEYE_PayPal_PPCP_Seller_Onboarding::instance()
+            ->angelleye_track_seller_onboarding_status_from_cache($merchant_id, false);
+        if (!is_array($result)) {
+            return $cached = false;
+        }
+        return $cached = angelleye_is_vaulting_enable($result);
     }
 
 }

--- a/ppcp-gateway/class-wc-gateway-base-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-base-angelleye.php
@@ -38,10 +38,15 @@ trait WC_Gateway_Base_AngellEYE
             $subscriptionSupports = [];
         }
 
+        // Only advertise tokenization when the admin-side toggle is ON *and* the
+        // connected PayPal merchant actually has ADVANCED_VAULTING provisioned.
+        // Admin settings page is exempt so the option remains discoverable there
+        // even before vault is activated.
+        $is_admin_settings_page = isset($_GET['page']) && isset($_GET['tab']) && 'wc-settings' === $_GET['page'] && 'checkout' === $_GET['tab'];
+        $tokenization_available = $this->enable_tokenized_payments && angelleye_ppcp_is_vault_capability_available();
         if (isset($_GET['paypal_order_id']) && isset($_GET['paypal_payer_id']) && $this->enable_tokenized_payments) {
             $this->supports = array_merge($baseSupports, $subscriptionSupports);
-        } elseif ($this->enable_tokenized_payments ||
-            (isset($_GET['page']) && isset($_GET['tab']) && 'wc-settings' === $_GET['page'] && 'checkout' === $_GET['tab'])) {
+        } elseif ($tokenization_available || $is_admin_settings_page) {
             $this->supports = array_merge($baseSupports, $subscriptionSupports, array('tokenization'));
         } else {
             $this->supports = $baseSupports;


### PR DESCRIPTION
## Summary

Stops the PPCP gateway from advertising tokenization support — and from injecting `payment_source.paypal.attributes.vault` into create_order — when the connected PayPal merchant doesn't actually have `ADVANCED_VAULTING` provisioned.

## The bug

TAM / merchant report: `payment_source.paypal.attributes.vault` was appearing on some PPCP create_order payloads and not others, with no obvious trigger. Same cart, same product, same Smart Button on the checkout page — but random vault injection.

### Root cause

Three things stacked up:

1. **Stale toggle** — the `enable_tokenized_payments` option stays truthy in the DB even after vault is deactivated on the PayPal side. The admin UI shows the checkbox as checked-but-disabled with a prominent "Activate PayPal Vault" button, but the stored value is still `'yes'`.
2. **Supports flag trusts the toggle alone** — `WC_Gateway_Base_AngellEYE::setGatewaySupports()` at [class-wc-gateway-base-angelleye.php:43-45](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/class-wc-gateway-base-angelleye.php#L43-L45) adds `'tokenization'` to `$this->supports` purely based on that stored value. Once it's on, WC auto-renders `<input id="wc-angelleye_ppcp-new-payment-method">` via its standard save-payment-method checkbox.
3. **Rule #2 was setting-independent** — `angelleye_ppcp_is_save_payment_method()` at [angelleye-paypal-ppcp-common-functions.php:898](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php#L898) fired whenever the POST carried the checkbox as `'true'`, regardless of `enable_tokenized_payments` or actual vault capability.

Net effect: a customer ticks "Save payment method to my account" → POST field set → rule #2 fires → `store_in_vault=ON_SUCCESS` injected → PayPal silently drops the vault attempt (or errors) since `PAYPAL_WALLET_VAULTING_ADVANCED` isn't approved on the seller's account.

## Changes

### 1. New capability helper — `angelleye_ppcp_is_vault_capability_available()`

Added in [angelleye-paypal-ppcp-common-functions.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php). Layered caching, cheapest-first:

1. **Per-request static** — repeated calls in one request cost nothing.
2. **`ae_seller_onboarding_status` transient** — 1-day TTL, shared across requests.
3. **PayPal Partner API** — called only when the transient is missing/expired, and the result re-primes the transient.

Routes through the existing `angelleye_track_seller_onboarding_status_from_cache($merchant_id, false)` method so we don't touch the admin-side force-refresh path. Uses `angelleye_is_vaulting_enable()` to interpret the response — same logic as the admin settings screen.

Defensive `defined('PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR')` + `class_exists()` guards make the helper fail closed (returns `false`) if invoked before plugin bootstrap — no fatal errors.

### 2. Gate `supports['tokenization']`

[class-wc-gateway-base-angelleye.php](wp-content/plugins/paypal-for-woocommerce/ppcp-gateway/class-wc-gateway-base-angelleye.php):

```php
$tokenization_available = $this->enable_tokenized_payments && angelleye_ppcp_is_vault_capability_available();
$is_admin_settings_page = isset($_GET['page']) && isset($_GET['tab']) && 'wc-settings' === $_GET['page'] && 'checkout' === $_GET['tab'];
...
} elseif ($tokenization_available || $is_admin_settings_page) {
    $this->supports = array_merge($baseSupports, $subscriptionSupports, array('tokenization'));
}
```

Tokenization is only advertised when the admin toggle is on AND vault is actually active on the PayPal side. The admin `wc-settings/checkout` screen stays exempt so the option remains visible and configurable before vault activation.

### 3. Safety net in `angelleye_ppcp_is_save_payment_method()`

Early-return `false` when the toggle is off or vault isn't live:

```php
if ($enable_tokenized_payments !== true || !angelleye_ppcp_is_vault_capability_available()) {
    return apply_filters('angelleye_ppcp_is_save_payment_method', false);
}
```

Closes the POST-tamper path and any `angelleye_ppcp_is_save_payment_method` filter-injected override from other plugins. Removed the redundant `$enable_tokenized_payments === true` checks inside the function body since the early guard covers them.

## Why this approach

- **No extra API calls in steady state** — frontend page loads hit the static cache or the transient. The Partner API is touched only when the cache is cold (first visit of the day, or right after transient invalidation).
- **No behavior change for correctly onboarded merchants** — if vault is active on PayPal, the helper returns true and the checkbox/vault injection flow is identical to before.
- **Self-healing after expiry** — the transient's 1-day TTL could leave frontends in a stale state; the helper re-primes on miss rather than failing closed.
- **Defense in depth** — hiding the checkbox is the UX fix; the early-return in `is_save_payment_method()` closes the code path even if the checkbox leaks through (tampering, third-party plugin, race).

## Test plan

- [ ] **Vault not activated on PayPal** (repro case): confirm the "Save payment method to my account" checkbox no longer renders on checkout, and create_order requests don't contain `payment_source.paypal.attributes.vault`
- [ ] **Vault activated on PayPal + toggle on**: confirm the checkbox renders and ticking it still produces `store_in_vault=ON_SUCCESS` in create_order (existing behavior preserved)
- [ ] **Admin settings screen**: confirm `enable_tokenized_payments` checkbox is still visible and interactable at WooCommerce → Settings → Payments → PayPal Complete Payments, regardless of vault activation state
- [ ] **Subscription in cart with vault live**: confirm vault attributes still injected (rule #1)
- [ ] **Product / cart-page Smart Button with vault live**: confirm vault attributes still injected (rule #3)
- [ ] **Blocks checkout**: confirm save-payment-method toggle hidden when vault not provisioned; present and functional when it is
- [ ] **Transient cold start**: delete the `ae_seller_onboarding_status` transient, load a frontend page, confirm exactly one Partner API call in the log and the transient is re-primed
- [ ] **Transient warm**: reload the same page, confirm zero Partner API calls
- [ ] **Early-init fatal check**: activate a plugin that reads `WC()->payment_gateways` at WP `init` priority < 1000 (e.g. YayMail Conditional Logic) and confirm no `Class not found` fatal

Fixes merchant reports of intermittent `store_in_vault` attributes on PPCP orders with non-vault-enabled accounts.
