### PR TITLE
Fix: trigger woocommerce_payment_successful_result on PPCP direct-capture

### DIFF
--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -1528,6 +1528,40 @@ if (!function_exists('angelleye_get_matched_shortcode_attributes')) {
 
 }
 
+if (!function_exists('angelleye_ppcp_trigger_payment_successful_result')) {
+
+    /**
+     * Apply WooCommerce's `woocommerce_payment_successful_result` filter for PPCP
+     * direct-capture paths that bypass WC_Checkout::process_order_payment().
+     *
+     * Some PPCP smart-button flows (CC, Apple Pay, Google Pay, PayPal Wallet) capture
+     * payment via a custom AJAX endpoint instead of the standard checkout submit, so
+     * WooCommerce never applies this filter for them. Plugins such as Germanized for
+     * WooCommerce hook that filter to send the order confirmation email immediately on
+     * order placement; without this call, those integrations are silent for cards/wallets.
+     *
+     * A per-request static guard prevents firing twice for the same order within one
+     * request, which would otherwise risk a duplicate confirmation email if a future
+     * code path also reaches WC_Checkout::process_order_payment() for the same order.
+     *
+     * @param array        $result Payment result array (must contain 'result' and 'redirect').
+     * @param int|WC_Order $order  Order or order ID.
+     * @return array Filtered result array.
+     */
+    function angelleye_ppcp_trigger_payment_successful_result($result, $order) {
+        static $fired = array();
+
+        $order_id = is_a($order, 'WC_Order') ? $order->get_id() : (int) $order;
+        if (!$order_id || isset($fired[$order_id])) {
+            return $result;
+        }
+        $fired[$order_id] = true;
+
+        return apply_filters('woocommerce_payment_successful_result', $result, $order_id);
+    }
+
+}
+
 if (!function_exists('angelleye_ppcp_get_awaiting_payment_order_id')) {
 
     function angelleye_ppcp_get_awaiting_payment_order_id() {

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
@@ -632,10 +632,17 @@ class AngellEYE_PayPal_PPCP_Front_Action {
                     AngellEye_Session_Manager::clear();
                     if (ob_get_length())
                         ob_end_clean();
-                    wp_send_json_success(array(
+                    $result = array(
                         'result' => 'success',
                         'redirect' => apply_filters('woocommerce_get_return_url', $order->get_checkout_order_received_url(), $order),
-                    ));
+                    );
+                    // This direct-capture path bypasses WC_Checkout::process_order_payment(), so the
+                    // woocommerce_payment_successful_result filter is never applied. Plugins like
+                    // Germanized for WooCommerce hook that filter to send the order confirmation email
+                    // immediately on order placement (legal requirement in DE). Apply it here so those
+                    // integrations behave the same as the standard checkout flow.
+                    $result = angelleye_ppcp_trigger_payment_successful_result($result, $order);
+                    wp_send_json_success($result);
                 } else {
                     AngellEye_Session_Manager::clear();
                     if (ob_get_length()) {


### PR DESCRIPTION
## Summary

For orders paid via Credit Card, Apple Pay, Google Pay, or PayPal Wallet using the PPCP smart button on the checkout page, the `woocommerce_payment_successful_result` filter was never applied. As a result, third-party plugins that rely on it — most notably **Germanized for WooCommerce**, which uses it to dispatch the legally required instant order confirmation email — never received the signal and the customer/admin emails were silently dropped.

The standard checkout submit, `direct_capture` (product/cart with skip-final-review), and `regular_capture` (PayPal full-page redirect return) all go through `WC_Checkout::process_order_payment()` which already applies the filter. The gap
was specifically `angelleye_ppcp_cc_capture()`, the shared AJAX entry point used by all four PPCP gateways' smart buttons on the checkout page.

## Changes

- **`ppcp-gateway/angelleye-paypal-ppcp-common-functions.php`** — added `angelleye_ppcp_trigger_payment_successful_result()`. Applies the
  `woocommerce_payment_successful_result` filter exactly like
  `WC_Checkout::process_order_payment()` does, with a per-request static guard
  to prevent the same order from firing twice within a single request.
- **`ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php`** — in
  `angelleye_ppcp_cc_capture()`, pass the success-result array through the helper
  before calling `wp_send_json_success`. Response shape is unchanged.

## Why this covers all PPCP gateways with a single change

The JS smart-button approval flow `approveOrder` → `checkoutFormCapture` →
`cc_capture` is shared across `angelleye_ppcp` (PayPal Wallet),
`angelleye_ppcp_cc` (Credit Card), `angelleye_ppcp_apple_pay`, and
`angelleye_ppcp_google_pay`. One fix in `cc_capture` resolves the missing
filter for all four gateways.

## Why this is safe

- The gateway `process_payment()` methods are unchanged; they continue to
  return through `WC_Checkout::process_order_payment()` which already applies
  the filter. The static guard in the helper catches any future overlap.
- `direct_capture` and `regular_capture` were not modified — they were never
  the gap.
- Order Pay endpoint stays silent on confirmation emails as intended:
  Germanized's `disable_pay_order_confirmation` removes itself from the filter
  on `woocommerce_before_pay_action`, so applying the filter here is a no-op
  for order-pay flows.
- JSON response shape is preserved (`{ result, redirect }`); the JS
  consumer only reads `data.data.redirect`.
- If no plugin hooks the filter, the helper is a transparent pass-through.

## Test plan

- [ ] DE store with Germanized active — place an order via smart button on
      checkout for each gateway, verify the order confirmation email is
      received immediately by the customer and admin:
  - [ ] PayPal Wallet (`angelleye_ppcp`)
  - [ ] Credit Card (`angelleye_ppcp_cc`)
  - [ ] Apple Pay (`angelleye_ppcp_apple_pay`)
  - [ ] Google Pay (`angelleye_ppcp_google_pay`)
- [ ] Verify no duplicate emails on flows that already worked:
  - [ ] Standard Place Order with PayPal Wallet (full-page redirect)
  - [ ] Product-page Apple/Google Pay with **Skip Final Review** = yes
        (`direct_capture`)
  - [ ] Product-page Apple/Google Pay with **Skip Final Review** = no
        (review on checkout, then Place Order)
- [ ] Order Pay endpoint (paying for an existing pending order) — confirm no
      duplicate confirmation email is sent.
- [ ] Non-Germanized store — confirm checkout flows still complete normally
      and the standard WooCommerce `customer_processing_order` email behaves
      as before.
