### PR TITLE
Align wc-admin/html-order-items.php with WooCommerce 10.7 core

### DIFF
--- a/template/wc-admin/html-order-items.php
+++ b/template/wc-admin/html-order-items.php
@@ -26,6 +26,15 @@ $discounts           = $order->get_items( 'discount' );
 $line_items_fee      = $order->get_items( 'fee' );
 $line_items_shipping = $order->get_items( 'shipping' );
 
+// Cost of Goods Sold flag — WooCommerce 9.5+ defines this in
+// html-order-items.php and the included views (e.g. html-order-fee.php)
+// read it. The class_exists guard keeps us safe on WC < 9.5 where the
+// controller doesn't exist; we fall back to false so the COGS UI is
+// simply omitted.
+$cogs_is_enabled = class_exists( '\Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController' )
+	? wc_get_container()->get( \Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController::class )->feature_is_enabled()
+	: false;
+
 if ( wc_tax_enabled() ) {
 	$order_taxes      = $order->get_taxes();
 	$tax_classes      = WC_Tax::get_tax_classes();
@@ -39,7 +48,10 @@ if ( wc_tax_enabled() ) {
 			<tr>
 				<th class="item sortable" colspan="2" data-sort="string-ins"><?php esc_html_e( 'Item', 'woocommerce' ); ?></th>
 				<?php do_action( 'woocommerce_admin_order_item_headers', $order ); ?>
-				<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
+				<?php if ( $cogs_is_enabled ) : ?>
+					<th class="item_cost_of_goods sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
+				<?php endif; ?>
+				<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 				<th class="quantity sortable" data-sort="int"><?php esc_html_e( 'Qty', 'woocommerce' ); ?></th>
 				<th class="line_cost sortable" data-sort="float"><?php esc_html_e( 'Total', 'woocommerce' ); ?></th>
 				<?php
@@ -117,8 +129,14 @@ if ( wc_tax_enabled() ) {
 				<li><strong><?php esc_html_e( 'Coupon(s)', 'woocommerce' ); ?></strong></li>
 				<?php
 				foreach ( $coupons as $item_id => $item ) :
-					$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' LIMIT 1;", $item->get_code() ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
-					$class   = $order->is_editable() ? 'code editable' : 'code';
+					$coupon_info = $item->get_meta( 'coupon_info' );
+					if ( $coupon_info ) {
+						$coupon_info = json_decode( $coupon_info, true );
+						$post_id     = $coupon_info[0]; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+					} else {
+						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+					}
+					$class = $order->is_editable() ? 'code editable' : 'code';
 					?>
 					<li class="<?php echo esc_attr( $class ); ?>">
 						<?php if ( $post_id ) : ?>
@@ -162,14 +180,14 @@ if ( wc_tax_enabled() ) {
 			</tr>
 		<?php if ( 0 < $order->get_total_discount() ) : ?>
 			<tr>
-				<td class="label"><?php esc_html_e( 'Coupon(s):', 'woocommerce' ); ?></td>
+				<td class="label"><?php esc_html_e( 'Discount:', 'woocommerce' ); ?></td>
 				<td width="1%"></td>
 				<td class="total">-
 					<?php echo wc_price( $order->get_total_discount(), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</td>
 			</tr>
 		<?php endif; ?>
-		<?php if ( 0 < $order->get_total_fees() ) : ?>
+		<?php if ( abs( $order->get_total_fees() ) > 0 ) : ?>
 			<tr>
 				<td class="label"><?php esc_html_e( 'Fees:', 'woocommerce' ); ?></td>
 				<td width="1%"></td>
@@ -271,6 +289,20 @@ if ( wc_tax_enabled() ) {
 				</td>
 			</tr>
 
+		</table>
+	<?php endif; ?>
+
+	<?php if ( $cogs_is_enabled ) : ?>
+		<div class="clear"></div>
+
+		<table class="wc-order-totals">
+			<tr>
+				<td class="label cost-total"><?php esc_html_e( 'Cost Total', 'woocommerce' ); ?>:</td>
+				<td width="1%"></td>
+				<td class="total cost-total">
+					<?php echo wp_kses_post( $order->get_cogs_total_value_html() ); ?>
+				</td>
+			</tr>
 		</table>
 	<?php endif; ?>
 


### PR DESCRIPTION
## Summary

Resync the plugin's `template/wc-admin/html-order-items.php` override against WooCommerce 10.7.0 core. This template only exists in the plugin to add the PPCP shipment-tracking column and to load the plugin's own item / shipping row templates — everything else had drifted behind core, including the recently reported `Undefined variable $cogs_is_enabled` warning that fires on every admin order page that contains a fee item under WC ≥ 9.5.

## Background

`template/wc-admin/html-order-items.php` is a copy of an older WC core view. WC core has since:

- Introduced the Cost of Goods Sold (COGS) feature in 9.5 — `html-order-items.php` now defines `$cogs_is_enabled` and the included views (`html-order-fee.php`, `html-order-refund.php`, the totals section) reference it. The plugin's override included `html-order-fee.php` directly without first defining the variable, so PHP emitted `Warning: Undefined variable $cogs_is_enabled in .../html-order-fee.php on line 30` on every admin order page with a fee.
- Renamed the "Cost" column header to "Price" and added a separate "Cost" column for COGS.
- Switched the coupon-post lookup from a code-only query to an `coupon_info` line-item meta (preferred) with a fallback that filters the `shop_coupon` search by `post_date < $order->get_date_created()` to avoid resolving to a newer coupon post sharing the same code.
- Renamed the order-totals row "Coupon(s):" to "Discount:".
- Loosened the fees-totals visibility condition from `0 < $order->get_total_fees()` to `abs($order->get_total_fees()) > 0` so negative fees show.
- Added a "Cost Total" totals table when COGS is enabled.

## What changed

`template/wc-admin/html-order-items.php` only:

- **Define `$cogs_is_enabled`** before the items table renders, with a `class_exists()` guard for backward compatibility on WC < 9.5 — falls back to `false` so the COGS UI is omitted.
- **Items header row**: add the new `<th class="item_cost_of_goods">Cost</th>` column (rendered only when `$cogs_is_enabled`); rename the existing `item_cost` header from "Cost" to "Price" to match core.
- **Coupon lookup**: read `$item->get_meta('coupon_info')` first; on miss, use the date-filtered `wpdb->get_var()` query.
- **Totals**: rename "Coupon(s):" → "Discount:"; switch the fees-row condition to `abs($order->get_total_fees()) > 0`.
- **New COGS totals table** at the bottom (immediately before the trailing action-hook table), echoing `$order->get_cogs_total_value_html()` when `$cogs_is_enabled` is true.

## Intentionally NOT aligned with core

- `<th class="ppcp_shipment_tracking">Shipment Tracking</th>` column in the items table — this is the reason the plugin override exists.
- `include ( PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/template/wc-admin/html-order-item.php')` and the matching `html-order-shipping.php` include — plugin's own row templates that render the shipment-tracking cell. (WC core uses `__DIR__ . '/html-order-item.php'`; the plugin's `template/wc-admin/` has those two files but does **not** ship `html-order-fee.php` or `html-order-refund.php`, so those still include from `WC_ABSPATH . 'includes/admin/meta-boxes/views/...'`.)
- `class_exists('Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController')` guard — keeps the template safe on WC versions older than 9.5.
- Order status comparison kept as `in_array($order->get_status(), array('processing','completed','refunded'), true)` rather than `array(OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::REFUNDED)`. Same string values; the plain-string form doesn't require the `Automattic\WooCommerce\Enums\OrderStatus` class (introduced in WC 10) to exist.

## Test plan

Tested against WooCommerce 10.7.0:

- [ ] Open an admin order edit screen that contains a fee line item — no `Undefined variable $cogs_is_enabled` warning in the PHP error log.
- [ ] With COGS feature **off** (default): items table shows the same columns as before plus the renamed "Price" header. No "Cost" column, no "Cost Total" totals row.
- [ ] With COGS feature **on**: extra "Cost" column appears in the items table; "Cost Total" totals row renders below the standard totals using `$order->get_cogs_total_value_html()`.
- [ ] The plugin's "Shipment Tracking" column header still renders (hidden by default per the inline `style="display:none"`).
- [ ] Coupon lookup: apply a coupon to an editable order, then create a newer coupon post with the same code. Reload the order — link still resolves to the original (older) coupon, not the new one (this is the WC core change to filter by `post_date < order_date`).
- [ ] Negative-fee scenario (e.g. a promotional fee with a negative amount): the "Fees:" totals row now renders; previously it was hidden by the `0 <` guard.
- [ ] Manual / API refund flows render the refund rows from `html-order-refund.php` without warnings.
- [ ] Verify on an older WC install (e.g. WC 8.x without COGS): page still renders, no fatals from the missing `CostOfGoodsSoldController` class (the `class_exists` guard returns false, COGS UI is omitted).