### PR TITLE
Fix bogus vault payment-token call when response has no setup_token

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -1266,7 +1266,13 @@ class AngellEYE_PayPal_PPCP_Payment {
                 $order->update_meta_data('_paypal_order_id', $this->api_response['id']);
                 $order->save_meta_data();
                 if ($this->api_response['status'] == 'COMPLETED') {
-                    if (isset($this->api_response['payment_source']['card']['attributes']['vault']['status']) && 'APPROVED' === $this->api_response['payment_source']['card']['attributes']['vault']['status']) {
+                    // vault.status = APPROVED only carries a setup_token for the
+                    // explicit setup-token vaulting flow. Some capture responses
+                    // come back with vault.status = APPROVED but no setup_token
+                    // (and no vault id) - there is nothing to exchange. Guard on
+                    // setup_token so we don't POST to /v3/vault/payment-tokens
+                    // with an empty id, which only triggers a failed API call.
+                    if (!empty($this->api_response['payment_source']['card']['attributes']['vault']['setup_token']) && isset($this->api_response['payment_source']['card']['attributes']['vault']['status']) && 'APPROVED' === $this->api_response['payment_source']['card']['attributes']['vault']['status']) {
                         $setup_token = $this->api_response['payment_source']['card']['attributes']['vault']['setup_token'];
                         $body_request = array();
                         $body_request['payment_source']['token'] = array(
@@ -1895,7 +1901,13 @@ class AngellEYE_PayPal_PPCP_Payment {
                 }
                 $payment_status = $this->api_response['purchase_units']['0']['payments']['authorizations']['0']['status'] ?? '';
                 if ($this->api_response['status'] == 'COMPLETED' && strtolower($payment_status) != "denied") {
-                    if (isset($this->api_response['payment_source']['card']['attributes']['vault']['status']) && 'APPROVED' === $this->api_response['payment_source']['card']['attributes']['vault']['status']) {
+                    // vault.status = APPROVED only carries a setup_token for the
+                    // explicit setup-token vaulting flow. Some capture responses
+                    // come back with vault.status = APPROVED but no setup_token
+                    // (and no vault id) - there is nothing to exchange. Guard on
+                    // setup_token so we don't POST to /v3/vault/payment-tokens
+                    // with an empty id, which only triggers a failed API call.
+                    if (!empty($this->api_response['payment_source']['card']['attributes']['vault']['setup_token']) && isset($this->api_response['payment_source']['card']['attributes']['vault']['status']) && 'APPROVED' === $this->api_response['payment_source']['card']['attributes']['vault']['status']) {
                         $setup_token = $this->api_response['payment_source']['card']['attributes']['vault']['setup_token'];
                         $body_request = array();
                         $body_request['payment_source']['token'] = array(


### PR DESCRIPTION
The COMPLETED-order capture and authorization handlers in class-angelleye-paypal-ppcp-payment.php exchanged a vaulting setup token for a permanent payment token whenever
payment_source.card.attributes.vault.status was 'APPROVED'.

Some capture responses come back with vault.status = APPROVED but no setup_token (and no vault id) - there is nothing to exchange. The old code read the missing setup_token key (PHP "Undefined array key" warning), built a request body with an empty 'id', and still fired a POST /v3/vault/payment-tokens call that could only fail.

Guard the APPROVED branch on a non-empty setup_token in both occurrences, so the payment-tokens endpoint is only hit when there is an actual setup token to exchange. The VAULTED branches are unchanged.