### PR TITLE
Fix PPCP Card Fields not rendering and Place Order button visible on the Order Pay page

### DIFF
--- a/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-helper-angelleye-v2.php
+++ b/angelleye-includes/express-checkout/class-wc-gateway-paypal-express-helper-angelleye-v2.php
@@ -791,7 +791,7 @@ class Angelleye_PayPal_Express_Checkout_Helper {
                 if (!isset($this->disallowed_funding_methods['paylater'])) {
                     array_push($enable_funding, 'paylater');
                 }
-                $is_cart = is_cart() && !WC()->cart->is_empty();
+                $is_cart = is_cart() && WC()->cart && !WC()->cart->is_empty();
                 $is_product = is_product();
                 $is_checkout = is_checkout();
                 $page = $is_cart ? 'cart' : ( $is_product ? 'product' : ( $is_checkout ? 'checkout' : null ) );

--- a/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
+++ b/ppcp-gateway/checkout-block/angelleye-ppcp-cc-block.php
@@ -53,7 +53,7 @@ final class AngellEYE_PPCP_CC_Block extends AbstractPaymentMethodType {
         $is_pay_page = '';
         if (is_product()) {
             $page = 'product';
-        } else if (is_cart() && !WC()->cart->is_empty()) {
+        } else if (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
             $page = 'cart';
         } elseif (is_checkout_pay_page()) {
             $page = 'checkout';

--- a/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php
+++ b/ppcp-gateway/checkout-block/angelleye-ppcp-checkout-block.php
@@ -52,7 +52,7 @@ final class AngellEYE_PPCP_Checkout_Block extends AbstractPaymentMethodType {
         $is_pay_page = '';
         if (is_product()) {
             $page = 'product';
-        } else if (is_cart() && !WC()->cart->is_empty()) {
+        } else if (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
             $page = 'cart';
         } elseif (is_checkout_pay_page()) {
             $page = 'checkout';

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -907,7 +907,7 @@ class AngellEYE_PayPal_PPCP_Payment {
         $page = null;
         if (isset($_GET) && !empty($_GET['from'])) {
             $page = $_GET['from'];
-        } elseif (is_cart() && !WC()->cart->is_empty()) {
+        } elseif (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
             $page = 'cart';
         } elseif (is_checkout() || is_checkout_pay_page()) {
             $page = 'checkout';

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -792,6 +792,22 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
         }
         $js_url = add_query_arg($smart_js_arg, 'https://www.paypal.com/sdk/js');
 
+        // On Order Pay there is no active shopping cart, so WC()->cart->total
+        // returns 0. The JS-side renderHostedButtons treats cart_total <= 0
+        // as the legacy free-trial flow and bails before mounting the SDK
+        // Card Fields. Use the order total on Order Pay so that guard
+        // recognises the real amount and the hosted fields mount.
+        $cart_total = WC()->cart->total;
+        if (is_checkout_pay_page()) {
+            global $wp;
+            if (isset($wp->query_vars['order-pay'])) {
+                $pay_order = wc_get_order(absint($wp->query_vars['order-pay']));
+                if ($pay_order) {
+                    $cart_total = $pay_order->get_total();
+                }
+            }
+        }
+
         wp_localize_script($ae_script_loader_handle, 'angelleye_ppcp_manager', array(
             'sandbox_mode' => (bool) $this->is_sandbox,
             'paypal_sdk_url' => $js_url,
@@ -818,7 +834,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
             'cc_capture' => add_query_arg(array('angelleye_ppcp_action' => 'cc_capture', 'utm_nooverride' => '1'), untrailingslashit(WC()->api_request_url('AngellEYE_PayPal_PPCP_Front_Action'))),
             'create_order_url' => add_query_arg(array('angelleye_ppcp_action' => 'create_order', 'utm_nooverride' => '1', 'from' => is_checkout_pay_page() ? 'pay_page' : $page), untrailingslashit(WC()->api_request_url('AngellEYE_PayPal_PPCP_Front_Action'))),
             'shipping_update_url' => add_query_arg(array('angelleye_ppcp_action' => 'shipping_address_update', 'utm_nooverride' => '1', 'from' => is_checkout_pay_page() ? 'pay_page' : $page), untrailingslashit(WC()->api_request_url('AngellEYE_PayPal_PPCP_Front_Action'))),
-            'cart_total' => WC()->cart->total,
+            'cart_total' => $cart_total,
             'paymentaction' => $this->paymentaction,
             'advanced_card_payments' => ($this->advanced_card_payments === true) ? 'yes' : 'no',
             'three_d_secure_contingency' => $this->three_d_secure_contingency,
@@ -866,8 +882,14 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
             // vault charge-upon-release case where the smart button bails
             // regardless of cart total. For carts with total > 0 the JS
             // saved-token toggle in canShowPlaceOrderBtn() handles visibility.
+            //
+            // Use the resolved $cart_total (Order Pay-aware) rather than
+            // WC()->cart->total directly: on Order Pay the cart is empty
+            // so WC()->cart->total is 0, which would otherwise force the
+            // Place Order button visible alongside the smart button even
+            // when the order has a real amount.
             'is_hide_place_order_button' => (
-                (function_exists('WC') && WC()->cart ? (float) WC()->cart->total : 1) <= 0
+                (float) $cart_total <= 0
                 || ($this->is_pre_order_item_in_cart() && $this->is_paypal_vault_used_for_pre_order() && $this->is_pre_order_charged_upon_release_in_cart())
             ) ? 'no' : 'yes',
         ));

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -434,7 +434,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
             angelleye_ppcp_add_css_js();
         } elseif(is_product() && $this->enable_product_button) {
             angelleye_ppcp_add_css_js();
-        } elseif (is_cart() && !WC()->cart->is_empty() && $this->enable_cart_button) {
+        } elseif (is_cart() && WC()->cart && !WC()->cart->is_empty() && $this->enable_cart_button) {
             angelleye_ppcp_add_css_js();
         } elseif (class_exists('\FKCart\Plugin') && $this->enable_funnelkit_cart_button) {
             // FunnelKit Cart is a floating widget visible on all frontend pages.
@@ -550,7 +550,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
         if (angelleye_ppcp_has_active_session() === true || angelleye_ppcp_is_subs_change_payment() === true) {
             if (is_product()) {
                 $page = 'product';
-            } else if (is_cart() && !WC()->cart->is_empty()) {
+            } else if (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
                 $page = 'cart';
             } elseif (is_checkout_pay_page()) {
                 $page = 'checkout';
@@ -624,7 +624,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
                 $apple_pay_btn_selector['angelleye_ppcp_product_apple_pay'] = '#angelleye_ppcp_product_apple_pay';
                 $google_pay_btn_selector['angelleye_ppcp_product_shortcode_google_pay'] = '#angelleye_ppcp_product_shortcode_google_pay';
                 $google_pay_btn_selector['angelleye_ppcp_product_google_pay'] = '#angelleye_ppcp_product_google_pay';
-            } elseif (is_cart() && !WC()->cart->is_empty()) {
+            } elseif (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
                 $page = 'cart';
                 if ($this->cart_button_position === 'top') {
                     $button_selector['angelleye_ppcp_cart_top'] = '#angelleye_ppcp_cart_top';
@@ -1926,7 +1926,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
         try {
             if (is_product()) {
                 $this->display_paypal_button_product_page($is_shortcode = 'yes');
-            } elseif (is_cart() && !WC()->cart->is_empty()) {
+            } elseif (is_cart() && WC()->cart && !WC()->cart->is_empty()) {
                 $this->display_paypal_button_cart_page($is_shortcode = 'yes');
             } elseif (is_checkout_pay_page()) {
                 $this->display_paypal_button_checkout_page($is_shortcode = 'yes');


### PR DESCRIPTION
## Summary

Fixes two related bugs on the WooCommerce **Order Pay** page (`?pay_for_order=true`):

1. **PPCP Advanced Card Fields didn't render.** The container `<div>`s were output, but the PayPal SDK iframes were never mounted, leaving customers unable to pay with a card.
2. **Place Order button stayed visible alongside the PayPal smart button.** Selecting PPCP showed both CTAs simultaneously.

Both stem from the same root cause and are fixed by the same patch.

## Root cause

On Order Pay there is no active shopping cart — the buyer is paying for an existing order — so `WC()->cart->total` returns `0`. Two downstream consumers of that value were not Order-Pay-aware:

- [`renderHostedButtons`](ppcp-gateway/js/wc-angelleye-common-functions.js) has a `parseFloat(angelleye_ppcp_manager.cart_total) <= 0` guard, added for the free-trial subscription flow that routes through WC's legacy plain card form (so the SDK Card Fields don't get mounted on top of those same DOM ids). On Order Pay that guard fired against the cart's `0`, not the actual order total, so the SDK was never invoked — independent of every other guard (`.CardFields` class, node identity, eligibility).
- The `is_hide_place_order_button` decision evaluated the same `WC()->cart->total <= 0` arm and force-returned `'no'` (i.e. "keep the Place Order button visible alongside the smart button") on every Order Pay request, regardless of the actual order amount.

Server-side: [class-angelleye-paypal-ppcp-smart-button.php](ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php) was passing `WC()->cart->total` directly into the `angelleye_ppcp_manager` localized array for both `'cart_total'` and the `is_hide_place_order_button` computation.

## Fix

Resolve `$cart_total` once, just before `wp_localize_script`, with an Order-Pay-aware override:

```php
$cart_total = WC()->cart->total;
if (is_checkout_pay_page()) {
    global $wp;
    if (isset($wp->query_vars['order-pay'])) {
        $pay_order = wc_get_order(absint($wp->query_vars['order-pay']));
        if ($pay_order) {
            $cart_total = $pay_order->get_total();
        }
    }
}
```

Use `$cart_total` for both:

- `'cart_total' => $cart_total` (was `WC()->cart->total`).
- `'is_hide_place_order_button' => ((float) $cart_total <= 0 || $preorderChargeUponRelease) ? 'no' : 'yes'`.

The pre-order vault-charge-upon-release OR-arm is untouched.

## Behavior matrix

| Scenario | `$cart_total` | `'cart_total'` JS value | `is_hide_place_order_button` | Pre-fix → Post-fix |
|---|---|---|---|---|
| Regular checkout, real total e.g. $50 | `WC()->cart->total` (50) | `50` | `'yes'` (hide Place Order) | identical |
| Regular checkout, free-trial $0 | `0` | `0` | `'no'` (Place Order is the only CTA) | identical |
| Pre-order vault charge-upon-release | `WC()->cart->total` | same | `'no'` (OR-arm) | identical |
| Cart / product page (where this enqueues) | `WC()->cart->total` | same | same outcome | identical |
| **Order Pay, real order total $100** | `$pay_order->get_total()` (100) | `100` | `'yes'` (hide Place Order) | **fixed** — was `0` / `'no'` |
| Order Pay, $0 order (free-trial) | `0` | `0` | `'no'` | correct (matches free-trial branch) |

Regular checkout passes the same expression as before (`WC()->cart->total`), so there's no behavioral change on that path.

## Files changed

- `ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php` — resolve `$cart_total` with Order Pay override; use it for `'cart_total'` and `'is_hide_place_order_button'`.

## Test plan

- [ ] **Order Pay, $100 order, CC selected:** Card Fields iframes mount, the Place Order button is hidden, smart button is the only CTA when switching to PPCP.
- [ ] **Order Pay, $100 order, switching methods:** flipping between PPCP and CC swaps the CTA correctly each time.
- [ ] **Regular checkout, real total:** behavior unchanged — fields render, smart button hides Place Order on PPCP.
- [ ] **Regular checkout, free-trial $0 cart:** WC's legacy plain card form still drives submission; Place Order remains visible.
- [ ] **Pre-order vault charge-upon-release in cart:** Place Order remains visible (OR-arm preserved).
- [ ] **DevTools console on Order Pay:** `angelleye_ppcp_manager.cart_total` equals the order total (e.g. `"100.00"`), and `angelleye_ppcp_manager.is_hide_place_order_button` is `'yes'` for a normal nonzero order.
