### PR TITLE
Fixed the venmo integration and save the Venmo user details in order note

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-payment.php
@@ -1328,6 +1328,19 @@ class AngellEYE_PayPal_PPCP_Payment {
                         $card_response_order_note .= 'Card type : ' . angelleye_ppcp_readable($payment_source['card']['type']);
                         $order->add_order_note($card_response_order_note);
                     }
+                    if (!empty($payment_source['venmo'])) {
+                        $venmo_response_order_note = __('Venmo Details', 'paypal-for-woocommerce');
+                        if (!empty($payment_source['venmo']['user_name'])) {
+                            $venmo_response_order_note .= "\n" . 'Username : ' . $payment_source['venmo']['user_name'];
+                        }
+                        if (!empty($payment_source['venmo']['email_address'])) {
+                            $venmo_response_order_note .= "\n" . 'Email : ' . $payment_source['venmo']['email_address'];
+                        }
+                        if (!empty($payment_source['venmo']['payer_id'])) {
+                            $venmo_response_order_note .= "\n" . 'Payer ID : ' . $payment_source['venmo']['payer_id'];
+                        }
+                        $order->add_order_note($venmo_response_order_note);
+                    }
                     foreach ($this->api_response['purchase_units'] as $captures_key => $captures) {
                         
                         $processor_response = isset($this->api_response['purchase_units'][$captures_key]['payments']['captures']['0']['processor_response']) ? $this->api_response['purchase_units'][$captures_key]['payments']['captures']['0']['processor_response'] : '';
@@ -1956,6 +1969,19 @@ class AngellEYE_PayPal_PPCP_Payment {
                         $card_response_order_note .= "\n";
                         $card_response_order_note .= 'Card type : ' . angelleye_ppcp_readable($payment_source['card']['type']);
                         $order->add_order_note($card_response_order_note);
+                    }
+                    if (!empty($payment_source['venmo'])) {
+                        $venmo_response_order_note = __('Venmo Details', 'paypal-for-woocommerce');
+                        if (!empty($payment_source['venmo']['user_name'])) {
+                            $venmo_response_order_note .= "\n" . 'Username : ' . $payment_source['venmo']['user_name'];
+                        }
+                        if (!empty($payment_source['venmo']['email_address'])) {
+                            $venmo_response_order_note .= "\n" . 'Email : ' . $payment_source['venmo']['email_address'];
+                        }
+                        if (!empty($payment_source['venmo']['payer_id'])) {
+                            $venmo_response_order_note .= "\n" . 'Payer ID : ' . $payment_source['venmo']['payer_id'];
+                        }
+                        $order->add_order_note($venmo_response_order_note);
                     }
                     $processor_response = $this->api_response['purchase_units']['0']['payments']['authorizations']['0']['processor_response'] ?? '';
                     if (!empty($processor_response['avs_code'])) {
@@ -3233,7 +3259,13 @@ class AngellEYE_PayPal_PPCP_Payment {
                         break;
                     case 'venmo':
                         $payment_method_name = 'venmo';
-                        $attributes = array('vault' => array('store_in_vault' => 'ON_SUCCESS', 'usage_type' => 'MERCHANT', 'permit_multiple_payment_tokens ' => true));
+                        // Note: the key here has a (now-removed) trailing space
+                        // historically — PayPal silently dropped it as an
+                        // unrecognized property, defaulting permit_multiple to
+                        // false, so a returning Venmo buyer kept getting fresh
+                        // vault ids instead of additional tokens under one
+                        // customer. Matches the paypal / apple_pay branches.
+                        $attributes = array('vault' => array('store_in_vault' => 'ON_SUCCESS', 'usage_type' => 'MERCHANT', 'permit_multiple_payment_tokens' => true));
                         $paypal_generated_customer_id = $this->ppcp_payment_token->angelleye_ppcp_get_paypal_generated_customer_id($this->is_sandbox);
                         if (!empty($paypal_generated_customer_id)) {
                             $attributes['customer'] = array('id' => $paypal_generated_customer_id);


### PR DESCRIPTION
## Summary

Audit and harden the PayPal **Venmo** integration in the PPCP gateway. Fixes a high-impact vault-attribute typo that was silently disabling multi-token support for Venmo buyers, and brings the post-capture order-note pattern in line with the existing card-details note so Venmo orders are actually identifiable in the admin timeline.

## Changes

### 1. Fix trailing-space typo in Venmo vault attributes (high impact)

[class-angelleye-paypal-ppcp-payment.php](ppcp-gateway/class-angelleye-paypal-ppcp-payment.php) — Venmo `case` of `angelleye_ppcp_add_payment_source_parameter()`:

```diff
- 'permit_multiple_payment_tokens ' => true   // trailing space inside the quote
+ 'permit_multiple_payment_tokens'  => true
```

PHP treated the misspelled key as a distinct array key, so the JSON body we POSTed to `/v2/checkout/orders` carried `"permit_multiple_payment_tokens "` — an unrecognized property — and PayPal silently dropped it, defaulting the flag to `false`. A returning Venmo buyer kept getting a fresh vault id on every checkout instead of accumulating tokens under one customer. The PayPal (line 3229) and Apple Pay (line 3261) branches already use the clean key; Venmo now matches.

### 2. Add a `Venmo Details` order note at capture time

Same file, both capture handlers (~line 1331 and ~line 1960). Inserted next to the existing `Card Details` note builder, with the same field-presence guards the rest of PFW uses:

```php
if (!empty($payment_source['venmo'])) {
    $venmo_response_order_note = __('Venmo Details', 'paypal-for-woocommerce');
    if (!empty($payment_source['venmo']['user_name'])) {
        $venmo_response_order_note .= "\n" . 'Username : ' . $payment_source['venmo']['user_name'];
    }
    if (!empty($payment_source['venmo']['email_address'])) {
        $venmo_response_order_note .= "\n" . 'Email : ' . $payment_source['venmo']['email_address'];
    }
    if (!empty($payment_source['venmo']['payer_id'])) {
        $venmo_response_order_note .= "\n" . 'Payer ID : ' . $payment_source['venmo']['payer_id'];
    }
    $order->add_order_note($venmo_response_order_note);
}
```

A Venmo capture now produces an admin-visible note like:

```
Venmo Details
Username : @cool-buyer-99
Email : buyer@example.com
Payer ID : ABCDEF123456
```

Each line is conditional, so a missing field doesn't produce a blank `Email :` stub. Mirrors the existing `Card Details` note shape so admin tooling that scans notes works the same for both.

## Scope of the audit (and what was deliberately left alone)

Full review of the Venmo path covered SDK loading, button rendering, create-order body, vault extraction, subscriptions support, vault-sync, and post-capture metadata.

The following items were investigated and confirmed **not to require code changes**:

- **`_angelleye_ppcp_used_payment_method` meta at capture time.** The buyer-Venmo path already writes this via the session-driven `update_meta_data()` at lines 1261 / 1896. The hard-coded `'paypal'` write at line 3806 is in a different code path (the PayPal-Wallet setup-token redemption flow) that Venmo doesn't traverse — adding a Venmo equivalent there would have been dead or actively wrong.
- **US-only country guard on `enable-funding=venmo`.** PFW relies on PayPal SDK's `.isEligible()` to hide the Venmo button in non-US contexts. That's the documented pattern, and adding a PHP-side country filter would be a behavior change rather than a bug fix.
- **`'Venmo'` literal fallback for username in `class-angelleye-paypal-ppcp-vault-sync.php`.** Display-only choice when neither `email_address` nor `payer_id` is returned; not affecting payment flow.

## Files changed

- `ppcp-gateway/class-angelleye-paypal-ppcp-payment.php`

## Test plan

- [ ] **Sandbox Venmo checkout (US buyer):** complete a Venmo payment from a US sandbox account.
  - Capture response inspected → `payment_source.venmo.attributes.vault.id` recorded as expected.
  - WC order timeline shows a `Venmo Details` note with whichever of `Username` / `Email` / `Payer ID` PayPal returned.
- [ ] **Repeat Venmo checkout with the same sandbox buyer** to exercise the multi-token path.
  - Second capture response carries a vault id, customer id matches the first capture, and the saved Venmo token shows up in the buyer's WC `Payment methods` UI.
  - Verifies that `permit_multiple_payment_tokens` is now honored.
- [ ] **Existing flows are unaffected:**
  - PayPal wallet checkout still writes a `_angelleye_ppcp_used_payment_method = 'paypal'` meta and saves a PayPal vault token.
  - Apple Pay & Card checkouts continue to produce their existing order notes and vault behavior.
  - Subscription renewals against an existing Venmo vault token continue to charge successfully (vault-sync helper is untouched).

## Risk

Low. The typo fix is one character; the order-note addition is purely additive and guarded with `!empty()` checks on every field, so it can't fatal on missing keys.
