### PR TITLE
Fix: Sync payment-methods.php template version header to WooCommerce 8.9.0

### DIFF
--- a/template/myaccount/payment-methods.php
+++ b/template/myaccount/payment-methods.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 2.6.0
+ * @version 8.9.0
  */
 defined('ABSPATH') || exit;
 


### PR DESCRIPTION
## Summary

Resolves the **"Version 2.6.0 is out of date. The core version is 8.9.0"** warning reported by clients in the WooCommerce **Status report → Templates** section for:

```
wp-content/plugins/paypal-for-woocommerce/template/myaccount/payment-methods.php
```

## Background

WooCommerce's template scan compares only the `@version` value in a template override's header against the matching core template — **not the actual code**. Our override of `myaccount/payment-methods.php` (which adds PayPal/Venmo/Apple Pay/card icons and vaulted payment-method display on the My Account page) still carried an old `2.6.0` header, while WooCommerce core stamps this template `8.9.0`. The mismatch produced the warning even though the override was functionally current.

## Changes

- Bumped `@version` header in `template/myaccount/payment-methods.php` from `2.6.0` → `8.9.0`.

## Verification

- Diffed the override against WooCommerce core `templates/myaccount/payment-methods.php` (8.9.0) — structure already matches (column loop, `woocommerce_before/after_account_payment_methods` hooks, per-column action hooks, add-payment-method button). Only intentional PPCP additions differ (icon rendering, vaulted-token listing, deprecated-tag action).
- Cross-checked **every** `.php` file under `/template/` against the WooCommerce core `templates/` tree. `myaccount/payment-methods.php` is the **only** path that collides with a core template; it now reports `plugin=8.9.0 core=8.9.0 OK`. All other templates (`emails/*`, `migration/*`, `wc-admin/*`, `admin.php`) do not mirror core template paths and are not version-checked.

## Impact

- **No functional change** — header-only update.
- Clears the Status report warning after users update to the release containing this fix.

## Notes

- This is the only WC-core template override in the plugin, so no other template version flags exist today.
- Future maintenance: if a later WooCommerce release revises this template past `8.9.0`, re-diff the override and bump the header again.
