### PR TITLE
Fix Google Pay/Apple Pay sliding-cart total: doubled amount and false empty-cart error

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
@@ -384,7 +384,14 @@ class AngellEYE_PayPal_PPCP_Front_Action {
                     }
                     $orderTotal = WC()->cart->get_total('');
                     $addToCart = $_REQUEST['angelleye_ppcp-add-to-cart'] ?? null;
-                    if (!empty($addToCart)) {
+                    // Empty the cart before re-adding so a product that is already in the cart
+                    // is not counted twice, which doubled the Google Pay/Apple Pay total when
+                    // the shipping-address-update callback fired for an item already in the cart.
+                    // Mirrors the guard used in the create_order branch above.
+                    if (!empty($addToCart) && angelleye_ppcp_get_order_total() > 0) {
+                        WC()->cart->empty_cart();
+                    }
+                    if (!empty($addToCart) && angelleye_ppcp_get_order_total() === 0) {
                         try {
                             if (!class_exists('AngellEYE_PayPal_PPCP_Product')) {
                                 include_once ( PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-angelleye-paypal-ppcp-product.php');

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -412,6 +412,12 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
         // Currently, This is to support the applepay, so that we can pass the total amount to SDK popup
         add_filter('woocommerce_update_order_review_fragments', array($this, 'add_order_checkout_data_for_direct_checkouts'), 99);
 
+        // Include the fresh cart totals in add-to-cart AJAX responses so express buttons
+        // (Google Pay/Apple Pay) rendered off the cart page — e.g. in a sliding cart on the
+        // shop/archive/product pages — read the updated total instead of the stale page-load
+        // value, which otherwise triggered a false "your shopping cart seems to be empty" error.
+        add_filter('woocommerce_add_to_cart_fragments', array($this, 'add_order_checkout_data_for_direct_checkouts'), 99);
+
         // This is utilised on cart page to inform the shipping changes or cart total changes in frontend
         add_action('woocommerce_after_cart_totals', [$this, 'add_cart_data_in_html'], 99);
 

--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -1255,6 +1255,17 @@ const angelleyeOrder = {
             jQuery(document.body).on('trigger_angelleye_ppcp_cc', function (event) {
                 angelleyeOrder.renderPaymentButtons();
             });
+            // Off the cart page (e.g. a sliding cart on shop/archive/product pages) adding an
+            // item fires added_to_cart rather than updated_cart_totals. Refresh the cached cart
+            // totals from the angelleye_payments_data fragment so express buttons read the fresh
+            // total instead of the stale page-load value, which otherwise surfaced a false
+            // "your shopping cart seems to be empty" error on the Google Pay/Apple Pay button.
+            jQuery(document.body).on('added_to_cart', function (event, fragments) {
+                if (fragments && typeof fragments['angelleye_payments_data'] !== 'undefined') {
+                    angelleyeOrder.updateCartTotalsInEnvironment(JSON.parse(fragments['angelleye_payments_data']));
+                    angelleyeOrder.renderPaymentButtons();
+                }
+            });
         },
         handleRaceConditionOnWooHooks: () => {
             // trigger_angelleye_ppcp_cc is fired by the Blocks-checkout

--- a/ppcp-gateway/js/wc-angelleye-common-functions.js
+++ b/ppcp-gateway/js/wc-angelleye-common-functions.js
@@ -280,6 +280,16 @@ const angelleyeOrder = {
             // FunnelKit sliding cart — server reads existing WC()->cart contents, no form serialization needed
             formData = 'angelleye_ppcp_payment_method_title=' + jQuery('#angelleye_ppcp_payment_method_title').val();
             formData += '&woocommerce-process-checkout-nonce=' + angelleye_ppcp_manager.woocommerce_process_checkout;
+            // Forward the address details (e.g. Google Pay / Apple Pay shipping-address-update
+            // callbacks) so the server can recalculate shipping against the existing cart —
+            // without appending angelleye_ppcp-add-to-cart, which would re-add the product and
+            // double the total for an item already in the sliding cart.
+            if (billingDetails) {
+                formData += '&billing_address_source=' + encodeURIComponent(JSON.stringify(billingDetails));
+            }
+            if (shippingDetails) {
+                formData += '&shipping_address_source=' + encodeURIComponent(JSON.stringify(shippingDetails));
+            }
             if (angelleyeOrder.ppcp_address !== null && angelleyeOrder.ppcp_address !== undefined && angelleyeOrder.ppcp_address !== '') {
                 formData += '&address=' + JSON.stringify(angelleyeOrder.ppcp_address);
             }
@@ -405,8 +415,11 @@ const angelleyeOrder = {
             }
     }
     },
-    shippingAddressUpdate: (shippingDetails, billingDetails, errorLogId) => {
-        return angelleyeOrder.createOrder({apiUrl: angelleye_ppcp_manager.shipping_update_url, shippingDetails, billingDetails, errorLogId});
+    shippingAddressUpdate: (shippingDetails, billingDetails, errorLogId, angelleye_ppcp_button_selector) => {
+        // Forward the button selector so createOrder keeps the sliding-cart (FKCart) context.
+        // Without it the shipping update is treated as a product-page buy-now and re-adds the
+        // product, doubling the cart total for an item already present in the sliding cart.
+        return angelleyeOrder.createOrder({angelleye_ppcp_button_selector, apiUrl: angelleye_ppcp_manager.shipping_update_url, shippingDetails, billingDetails, errorLogId});
     },
     triggerPaymentCancelEvent: () => {
         jQuery(document.body).trigger('angelleye_paypal_oncancel');

--- a/ppcp-gateway/js/wc-gateway-ppcp-angelleye-apple-pay.js
+++ b/ppcp-gateway/js/wc-gateway-ppcp-angelleye-apple-pay.js
@@ -247,7 +247,7 @@ class ApplePayCheckoutButton {
             };
 
             try {
-                let response = await angelleyeOrder.shippingAddressUpdate({shippingDetails: event.shippingContact});
+                let response = await angelleyeOrder.shippingAddressUpdate({shippingDetails: event.shippingContact}, undefined, undefined, containerSelector);
                 console.log('shipping update response', response);
                 if (typeof response.totalAmount !== 'undefined') {
                     angelleyeOrder.updateCartTotalsInEnvironment(response);

--- a/ppcp-gateway/js/wc-gateway-ppcp-angelleye-google-pay.js
+++ b/ppcp-gateway/js/wc-gateway-ppcp-angelleye-google-pay.js
@@ -157,7 +157,7 @@ class GooglePayCheckoutButton {
                         locality: shippingAddress.locality,
                         postalCode: shippingAddress.postalCode
                     };
-                    let response = await angelleyeOrder.shippingAddressUpdate({shippingDetails: shippingDetails});
+                    let response = await angelleyeOrder.shippingAddressUpdate({shippingDetails: shippingDetails}, undefined, undefined, additionalData.thisObject.containerSelector);
                     if (typeof response.totalAmount !== 'undefined') {
                         angelleyeOrder.updateCartTotalsInEnvironment(response);
                         paymentDataRequestUpdate.newTransactionInfo = additionalData.thisObject.getGoogleTransactionInfo();


### PR DESCRIPTION
## Summary

Fixes two related issues with the Google Pay / Apple Pay express buttons in the FunnelKit sliding cart.

### 1. Doubled total on the shipping-address-update callback

The `shipping_address_update` AJAX handler re-added the already-in-cart product before recomputing the total, doubling the item amount (e.g. \$3.00 item + \$0.20 shipping shown as \$6.20 instead of \$3.20). Google Pay exposed it because it fires the shipping update on the `INITIALIZE` trigger the moment the sheet opens.

**Fix:** forward the button selector through `shippingAddressUpdate` → `createOrder` so an FKCart sliding-cart button keeps cart context instead of being treated as a product-page buy-now (which appended `angelleye_ppcp-add-to-cart`). The FKCart branch now also forwards the billing/shipping address so shipping still recalculates against the existing cart without re-adding the product. As defense-in-depth, the `shipping_address_update` handler empties the cart before re-adding (mirroring the `create_order` guard) so the re-add is idempotent for the product-page buy-now case.

### 2. False "your shopping cart seems to be empty" error off the cart page

Express buttons read the transaction total from `angelleye_cart_totals`, localized at page load and only refreshed on cart/checkout events (`updated_cart_totals`). Adding an item on the shop/archive/product page (e.g. via the sliding cart) left the cached total stale, so clicking the button read a total of 0 and showed a false empty-cart error even though the server-side cart was not empty.

**Fix:** register the cart-totals fragment on `woocommerce_add_to_cart_fragments` so add-to-cart AJAX responses carry fresh totals, and refresh `angelleye_cart_totals` from that fragment on the `added_to_cart` event, then re-render the buttons.

## Changed files

- `ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php` — idempotent re-add guard in `shipping_address_update`
- `ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php` — register totals fragment on `woocommerce_add_to_cart_fragments`
- `ppcp-gateway/js/wc-angelleye-common-functions.js` — forward selector + address in `shippingAddressUpdate`/FKCart branch; refresh totals on `added_to_cart`
- `ppcp-gateway/js/wc-gateway-ppcp-angelleye-google-pay.js` — pass container selector into `shippingAddressUpdate`
- `ppcp-gateway/js/wc-gateway-ppcp-angelleye-apple-pay.js` — pass container selector into `shippingAddressUpdate`

## Testing

Doubled total:
1. Add a product (e.g. \$3.00 + \$0.20 shipping) to the sliding cart on a product page.
2. Open the sliding cart and open the Google Pay sheet.
3. Total shows \$3.20 (previously \$6.20); multi-item carts keep all items.
4. Product-page buy-now still works, including after changing the shipping address in the sheet.

Empty-cart error:
1. Empty cart → load the shop page → add an item → open the sliding cart → click Google Pay.
2. Button shows the correct total with no empty-cart error.
3. Add a second item → total updates again.

Fixes #2205