### PR TITLE
Fix PPCP disconnect by saving settings before Apple Pay domain unregister (#2208)

### DIFF
--- a/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
@@ -127,42 +127,48 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
 
     public function process_admin_options() {
         delete_transient(AE_FEE);
-        $cacheCleared = false;
-        $clearCache = function () {
-            delete_option('ae_apple_pay_domain_reg_retries');
-            delete_transient('ae_seller_onboarding_status');
-            delete_transient('angelleye_apple_pay_domain_list_cache');
-            return true;
-        };
-        if (!isset($_POST['woocommerce_angelleye_ppcp_enabled']) || $_POST['woocommerce_angelleye_ppcp_enabled'] == "0") {
-            // run the automatic domain remove feature
-            try {
-                AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::autoUnRegisterDomain();
-            } catch (Exception $exception) {
-                $this->api_log->log("The exception was created on line: " . $exception->getFile() . ' ' .$exception->getLine(), 'error');
-                $this->api_log->log($exception->getMessage(), 'error');
-            }
-            $cacheCleared = $clearCache();
-        } else {
-            $oldSandboxMode = $this->get_option('testmode', 'no') == 'yes';
-            $newSandboxMode = isset($_POST['woocommerce_angelleye_ppcp_testmode']);
-            if ($oldSandboxMode != $newSandboxMode) {
-                $cacheCleared = $clearCache();
-            }
-        }
+        $gateway_being_disabled = (!isset($_POST['woocommerce_angelleye_ppcp_enabled']) || $_POST['woocommerce_angelleye_ppcp_enabled'] == "0");
+        // Capture the previous test-mode value before the settings are saved below.
+        $oldSandboxMode = $this->get_option('testmode', 'no') == 'yes';
+        $newSandboxMode = isset($_POST['woocommerce_angelleye_ppcp_testmode']);
+
+        // Persist this gateway's own settings.
         parent::process_admin_options();
+
         // Clear FunnelKit Cart cache so frontend reflects PFW button changes immediately.
         // FKCart's cache helper handles WP cache, WP Rocket, Autoptimize, W3TC, LiteSpeed,
         // WP Fastest Cache, and WP Super Cache (used by SiteGround SG Optimizer).
         if (class_exists('\FKCart\Admin\Admin_App') && method_exists('\FKCart\Admin\Admin_App', 'maybe_clear_cache')) {
             \FKCart\Admin\Admin_App::maybe_clear_cache();
         }
-        if ($cacheCleared) {
-            if (ob_get_length()) {
-                ob_end_clean();
+
+        // IMPORTANT: this handler is inherited by the Apple Pay and Google Pay
+        // subscription gateways, which are all hooked to this same
+        // (woocommerce_update_options_payment_gateways_angelleye_ppcp) save action.
+        // The account-level cleanup below must run only for the primary gateway, and
+        // must NOT redirect/exit here — doing so aborts the remaining gateways' saves
+        // (whichever instance fired first would win), which is what previously kept
+        // Disconnect from ever persisting to woocommerce_angelleye_ppcp_settings.
+        if ($this->id !== 'angelleye_ppcp') {
+            return;
+        }
+
+        if ($gateway_being_disabled || $oldSandboxMode !== $newSandboxMode) {
+            delete_option('ae_apple_pay_domain_reg_retries');
+            delete_transient('ae_seller_onboarding_status');
+            delete_transient('angelleye_apple_pay_domain_list_cache');
+        }
+
+        if ($gateway_being_disabled) {
+            // Best-effort Apple Pay domain removal. The settings were already saved
+            // above, so a slow or failed PayPal call here cannot undo the change; the
+            // \Throwable guard also keeps any error from bubbling up.
+            try {
+                AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::autoUnRegisterDomain();
+            } catch (\Throwable $exception) {
+                $this->api_log->log("The exception was created on line: " . $exception->getFile() . ' ' . $exception->getLine(), 'error');
+                $this->api_log->log($exception->getMessage(), 'error');
             }
-            wp_redirect(admin_url('admin.php?page=wc-settings&tab=checkout&section=angelleye_ppcp'));
-            die;
         }
     }
 


### PR DESCRIPTION
Fixes #2208

### Root cause
The PPCP settings screen saves three gateway instances on the same action, `woocommerce_update_options_payment_gateways_angelleye_ppcp`:

- `WC_Gateway_PPCP_AngellEYE_Apple_Pay_Subscriptions` (id `angelleye_ppcp_apple_pay`)
- `WC_Gateway_PPCP_AngellEYE_Google_Pay_Subscriptions` (id `angelleye_ppcp_google_pay`)
- `WC_Gateway_PPCP_AngellEYE_Subscriptions` (id `angelleye_ppcp`)

All three inherit `WC_Gateway_PPCP_AngellEYE::process_admin_options()`. On the "gateway disabled" path (which Disconnect triggers by unchecking Enable) it ran a blocking Apple Pay call and then `wp_redirect() … die()`.

The Apple Pay instance runs first. Because the disable check is hard-coded to the main `woocommerce_angelleye_ppcp_enabled` POST key, that first instance also takes the disable branch, saves *its own* option, and then `die()`s — killing the request before the **primary** gateway runs. As a result `woocommerce_angelleye_ppcp_settings` (the real merchant ID and enabled flag) is never written, so Disconnect silently does nothing. Normal saves are unaffected because they don't take the disable/`die` path.

### Fix
`process_admin_options()` now:

- Always calls `parent::process_admin_options()` to persist the gateway's own settings.
- Returns early for the non-primary (Apple Pay / Google Pay) instances, so it never redirects or exits and never aborts the remaining gateways' saves.
- Runs the account-level cleanup (cache/transient clears and the best-effort Apple Pay domain unregister) only on the primary `angelleye_ppcp` gateway, after its settings are saved, guarded by `catch (\Throwable)`.
- Removes the `wp_redirect()/die()` entirely and lets WooCommerce perform its normal post-save redirect.

### Result
- Disconnect reliably clears the merchant ID and disables the gateway, and it stays disconnected on reload.
- All PPCP settings (including the subscription-variant gateways) save on the same submit as before.
- A slow or failing Apple Pay call can no longer discard the save.

### Testing
- Reproduced the failure: through the real save action the disconnect did not persist (fresh DB still showed the merchant ID); confirmed the Apple Pay instance ran first and `die()`d.
- After the fix, through the real save action: `sandbox_merchant_id` is cleared and `enabled = no`; three subsequent settings-page loads keep it disconnected (no auto-reconnect).
- Verified normal setting changes (text and checkbox fields) still save.
- `php -l` passes.
