### PR TITLE
Suppress Google Pay / Apple Pay when multi-account routing resolves multiple merchant IDs (fixes #2211)

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -781,6 +781,17 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
             $google_pay_btn_selector = [];
         }
 
+        // Google Pay / Apple Pay do not support PayPal multi-seller mode (merchant-id=*).
+        // When multi-account routing resolves more than one payee for the current cart,
+        // suppress both wallets so the SDK does not fail with googlepay_config_error /
+        // "Not Eligible for GooglePay Payments". See https://github.com/angelleye/paypal-woocommerce/issues/2211
+        if (is_array($this->sdk_merchant_id) && count($this->sdk_merchant_id) > 1) {
+            $this->enable_google_pay = false;
+            $this->enable_apple_pay = false;
+            $google_pay_btn_selector = [];
+            $apple_pay_btn_selector = [];
+        }
+
         if ($this->enabled_pay_later_messaging) {
             array_push($components, 'messages');
         }
@@ -929,6 +940,12 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
                     $customCss .= implode(',', $hideSelectors) . '{display:none !important;}';
                 }
             }
+        }
+        // Google Pay / Apple Pay are suppressed for multi-seller carts (see the merchant-id=* guard
+        // in enqueue_scripts); also hide their payment method rows on the checkout page so a dead
+        // gateway option is not shown. https://github.com/angelleye/paypal-woocommerce/issues/2211
+        if (is_array($this->sdk_merchant_id) && count($this->sdk_merchant_id) > 1) {
+            $customCss .= '.wc_payment_method.payment_method_angelleye_ppcp_google_pay, .payment_box.payment_method_angelleye_ppcp_google_pay, .wc_payment_method.payment_method_angelleye_ppcp_apple_pay, .payment_box.payment_method_angelleye_ppcp_apple_pay {display:none !important;}';
         }
         wp_add_inline_style($this->angelleye_ppcp_plugin_name, $customCss);
         if (is_account_page()) {


### PR DESCRIPTION
Fixes #2211

## Problem

When the Multi-Account Management plugin resolves **more than one PayPal merchant ID** for the current cart (multi-vendor cart, site-owner commission rule, or a product page with another vendor's item in the cart), the SDK is loaded in multi-seller mode:

```
https://www.paypal.com/sdk/js?...&merchant-id=*&components=buttons,googlepay
```

PayPal's Google Pay component (and Apple Pay) does not support the multi-seller mode (`merchant-id=*`), so `Googlepay().config()` fails with:

```
googlepay_config_error
Uncaught (in promise) PayPalGooglePayError: Not Eligible for GooglePay Payments
```

## Changes

`ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php`:

1. **`enqueue_scripts()`** — after `getClientIdMerchantId()` has resolved `sdk_merchant_id`, if the list contains 2+ merchants, disable `enable_google_pay` / `enable_apple_pay` and clear both wallet button selector arrays (same pattern as the existing subscription guard). The `googlepay`/`applepay` components are then no longer requested from the SDK and no wallet buttons are rendered.

2. **`enqueue_styles()`** — for the same multi-seller condition, append inline CSS hiding the `payment_method_angelleye_ppcp_google_pay` / `payment_method_angelleye_ppcp_apple_pay` rows on the classic checkout, so a non-functional gateway option is not shown. (Apple Pay already has a default-hide CSS rule; Google Pay did not.) `enqueue_styles` runs at priority 10, after `enqueue_scripts` (priority 9), so `sdk_merchant_id` is already resolved.

## Behavior after the fix

| Scenario | SDK `merchant-id` | Google Pay / Apple Pay |
|---|---|---|
| Single merchant resolved | concrete ID | shown, works as before |
| Load balancer mode (always one account) | concrete ID | shown, works as before |
| 2+ merchants resolved (multi-vendor / commission) | `*` | cleanly suppressed; PayPal, Venmo, Pay Later unaffected |

## Not included (tracked in #2211 as follow-ups)

- Double `apply_filters('angelleye_ppcp_merchant_id')` call in `getClientIdMerchantId()` (advances the load balancer twice per page render)
- Render-time vs order-time payee mismatch for product page express checkout
- Offering wallets on commission-enabled stores (would require single payee + post-capture commission transfer)
