### PR TITLE
Preserve PPCP session during internal cart rebuild in wallet express flows (fixes #2213)

### DIFF
--- a/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php
@@ -300,7 +300,7 @@ class AngellEYE_PayPal_PPCP_Front_Action {
                             $addToCart = $_REQUEST['angelleye_ppcp-add-to-cart'] ?? null;
 
                             if (!empty($addToCart) && angelleye_ppcp_get_order_total() > 0) {
-                                WC()->cart->empty_cart();
+                                $this->angelleye_ppcp_empty_cart_preserving_session();
                             }
 
                             if (angelleye_ppcp_get_order_total() === 0 && !empty($addToCart)) {
@@ -387,9 +387,12 @@ class AngellEYE_PayPal_PPCP_Front_Action {
                     // Empty the cart before re-adding so a product that is already in the cart
                     // is not counted twice, which doubled the Google Pay/Apple Pay total when
                     // the shipping-address-update callback fired for an item already in the cart.
-                    // Mirrors the guard used in the create_order branch above.
+                    // Mirrors the guard used in the create_order branch above. The session-clear
+                    // listener is suspended: this callback also runs after the buyer authorizes
+                    // the payment, and clearing the PPCP session here loses reference_id and
+                    // aborts the capture in the subsequent direct_capture request.
                     if (!empty($addToCart) && angelleye_ppcp_get_order_total() > 0) {
-                        WC()->cart->empty_cart();
+                        $this->angelleye_ppcp_empty_cart_preserving_session();
                     }
                     if (!empty($addToCart) && angelleye_ppcp_get_order_total() === 0) {
                         try {
@@ -868,6 +871,25 @@ class AngellEYE_PayPal_PPCP_Front_Action {
 
     public function angelleye_ppcp_direct_capture() {
         $this->angelleye_ppcp_create_woo_order();
+    }
+
+    /**
+     * Empties the cart for the plugin's own empty-and-re-add rebuild without
+     * destroying the in-flight PPCP checkout session.
+     *
+     * WC()->cart->empty_cart() fires woocommerce_cart_emptied, which is hooked to
+     * AngellEYE_PayPal_PPCP_Smart_Button::maybe_clear_session_data() so that a
+     * customer emptying their cart clears any stale PayPal session. During the
+     * internal idempotent re-add (create_order / shipping_address_update handlers)
+     * that listener must be suspended: the post-authorization shipping update
+     * otherwise wipes reference_id/paypal_order_id mid-payment and the capture
+     * fails with "_paypal_reference_id is missing in the update_order call.".
+     */
+    private function angelleye_ppcp_empty_cart_preserving_session() {
+        $smart_button = AngellEYE_PayPal_PPCP_Smart_Button::instance();
+        remove_action('woocommerce_cart_emptied', array($smart_button, 'maybe_clear_session_data'));
+        WC()->cart->empty_cart();
+        add_action('woocommerce_cart_emptied', array($smart_button, 'maybe_clear_session_data'));
     }
 
     public function angelleye_ppcp_download_zip_file($github_zip_url, $plugin_zip_path) {


### PR DESCRIPTION
Fixes #2213

## Problem

Google Pay express checkout from the product page fails after the buyer authorizes the payment. The customer is redirected to the checkout page with:

```
Unfortunately your payment could not be completed. Please try again.
Sorry, your session has expired.
```

Log evidence:

```
03:52:14  PPCP Action: Create Order → order created (CREATED)
03:52:20  ERROR _paypal_reference_id is missing in the update_order call.
03:52:22  (customer lands back on checkout with the error notices)
```

## Root Cause

The post-authorization shipping-address update destroys the plugin's checkout session mid-payment:

1. `createOrder` succeeds; `AngellEye_Session_Manager` holds `reference_id`, `paypal_order_id`, etc.
2. After the buyer authorizes in the Google Pay sheet, the JS calls `shippingAddressUpdate`. The product-page form still carries the hidden `angelleye_ppcp-add-to-cart` input.
3. The `shipping_address_update` handler's idempotent re-add guard calls `WC()->cart->empty_cart()` before re-adding the product.
4. `empty_cart()` fires `woocommerce_cart_emptied` → `AngellEYE_PayPal_PPCP_Smart_Button::maybe_clear_session_data()` → `AngellEye_Session_Manager::clear()` — the whole PPCP session is wiped while the payment is in flight.
5. `direct_capture` re-seeds only `paypal_order_id`/`paypal_payer_id` from the URL; `angelleye_ppcp_update_order()` can't resolve `reference_id` (session gone, and the `_paypal_reference_id` order-meta fallback is never written in express flows), so the capture aborts and the customer is bounced to checkout.

The `woocommerce_cart_emptied` listener exists so a *customer* emptying their cart clears any stale PayPal session. It should not treat the plugin's own internal empty-and-re-add rebuild as that event. Apple Pay express is exposed to the same mechanism.

## Changes

`ppcp-gateway/class-angelleye-paypal-ppcp-front-action.php`:

1. New private helper `angelleye_ppcp_empty_cart_preserving_session()` — suspends the `woocommerce_cart_emptied` → `maybe_clear_session_data` listener, empties the cart, restores the listener.
2. Both internal rebuild sites in `handle_wc_api()` now use the helper instead of a bare `WC()->cart->empty_cart()`:
   - the `create_order` product branch
   - the `shipping_address_update` branch (the one that broke the capture)

## Behavior after the fix

| Scenario | Before | After |
|---|---|---|
| Product page → Google Pay / Apple Pay express → authorize | Session wiped; capture aborts; "payment could not be completed" / "session has expired" | Capture completes; customer lands on order-received page |
| Customer empties their cart | Stale PayPal session cleared | Unchanged — still cleared |
| Sliding-cart / buy-now re-add idempotency (#2205) | Cart rebuilt correctly | Unchanged — same empty-and-re-add, session preserved |

## Testing

- Product page → Google Pay → authorize: capture call follows Create Order in the log; no `_paypal_reference_id is missing` error; order-received page reached.
- Re-test the #2205 sliding-cart scenario (no doubled total) and a cart-page Google Pay payment as sanity checks.
