### PR TITLE
Record BN code in tracker metadata and fall back to the envelope for the debug id

### DIFF
--- a/angelleye-includes/angelleye-payment-logger.php
+++ b/angelleye-includes/angelleye-payment-logger.php
@@ -207,6 +207,7 @@ class AngellEYE_PFW_Payment_Logger {
                 'pfw_version' => defined('VERSION_PFW') ? VERSION_PFW : '',
                 'woocommerce_version' => defined('WC_VERSION') ? WC_VERSION : '',
                 'wp_version' => get_bloginfo('version'),
+                'bn' => angelleye_ppcp_get_partner_attribution_id(),
             ];
             $meta = !empty($request_param['meta']) && is_array($request_param['meta'])
                 ? array_merge($env_meta, $request_param['meta'])

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-response.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-response.php
@@ -92,11 +92,21 @@ class AngellEYE_PayPal_PPCP_Response {
                 if (201 < $status_code && $action_name !== 'update_order') {
                     delete_transient('is_angelleye_aws_down');
                 }
-                $response = !empty($body) ? json_decode($body, true) : '';
-                $response = isset($response['body']) ? $response['body'] : $response;
+                $decoded = !empty($body) ? json_decode($body, true) : '';
+                $response = isset($decoded['body']) ? $decoded['body'] : $decoded;
                 $this->angelleye_ppcp_write_log($url, $request, $paypal_api_response, $action_name);
                 if (strpos($url, 'paypal.com') !== false) {
+                    // First-party calls reach PayPal directly, so the debug id
+                    // arrives as a real response header. Third-party calls go
+                    // through the middleware, which echoes the same header back
+                    // - but only on builds new enough to do so, and only if no
+                    // proxy in front of the site strips unknown headers. Fall
+                    // back to the copy the middleware nests in its JSON
+                    // envelope so the id is recorded either way.
                     $debug_id = wp_remote_retrieve_header($paypal_api_response, 'Paypal-Debug-Id');
+                    if (empty($debug_id) && is_array($decoded) && !empty($decoded['headers'])) {
+                        $debug_id = $this->angelleye_ppcp_parse_headers($decoded['headers'], 'paypal-debug-id');
+                    }
                     do_action('angelleye_ppcp_request_respose_data', $request, $response, $action_name, $debug_id);
                 }
                 return $response;


### PR DESCRIPTION
Two related chores on the TPV tracker payload.

## 1. Fall back to the middleware envelope for the PayPal debug id

`debug_id` was blank on roughly 99% of PPCP records in the tracker.

It is read as an HTTP response header:

```php
$debug_id = wp_remote_retrieve_header($paypal_api_response, 'Paypal-Debug-Id');
```

That header only exists on first-party calls, where the site reaches `api-m.paypal.com` directly with its own credentials. Third-party merchants — everyone onboarded through Connect, i.e. almost all of them — go through the middleware, so the lookup inspected the middleware's own response headers and found nothing.

The value was never lost. The middleware returns PayPal's full header set inside its JSON envelope, and `parse_response()` was discarding that envelope one line before the id was needed.

The middleware now also echoes the header back under PayPal's own name (angelleye/ppcp-merchant-service#25, deployed), which fixes this for already-released plugin versions with no update required. This change is the belt-and-braces half: the header lookup stays primary, and the envelope is used only when it comes back empty — covering sites talking to an older middleware build, and any proxy that strips unknown response headers.

Also wires up `angelleye_ppcp_parse_headers()`, which was written for exactly this and had never been called from anywhere.

## 2. Record the BN code in tracker metadata

Tracked payments carried no partner attribution, so records could not be grouped by the BN code they billed under. One line — it now goes out as `bn` alongside the existing environment metadata:

```json
{"php_version":"8.3.0","pfw_version":"3.9.9","woocommerce_version":"9.1.0","wp_version":"6.5.2","bn":"AngellEYELLC_SP_AwesomeMotive"}
```

Uses `angelleye_ppcp_get_partner_attribution_id()` rather than reading `PAYPAL_PARTNER_ATTRIBUTION_ID` directly, so the value reflects any site override applied through the `angelleye_paypal_partner_attribution_id` filter, and stays the single source of truth shared with the outgoing `PayPal-Partner-Attribution-Id` header instead of a second copy of the constant that could drift.

No guard is needed around the call: `init()` runs `bootstrap_ppcp_runtime()` — which includes `angelleye-paypal-ppcp-common-functions.php` — before the Payflow, Braintree and legacy REST gateway files are loaded, and `angelleye_tpv_request()` only runs during an actual payment, well after that.

## Testing

- `php -l` clean on both files
- Debug id fallback exercised against real envelope headers captured from a production `wc-log` line, including the `set-cookie` array — resolves correctly, and returns empty rather than warning when the envelope has no `headers`
- BN code verified end to end by running the real logger with the WordPress surface stubbed and capturing the posted payload, including the case where caller-supplied `meta` is merged in and `bn` must survive the merge
- Confirmed the existing `php_version` / `pfw_version` / `woocommerce_version` / `wp_version` keys and the `debug_id` field are unaffected

## Notes

For third-party PPCP the BN code actually sent to PayPal is injected by the middleware from its own S3 config (`partner_attribution_id`), not by the plugin. Both are currently `AngellEYELLC_SP_AwesomeMotive`, so `bn` is accurate today, but they are independent values that could diverge. Making it authoritative for that path would mean having the middleware report the code it applied.

Unchanged and worth a separate ticket: `angelleye_ppcp_tpv_tracking()` hardcodes `status = 'Success'`, so PayPal-side declines are recorded as successes. They will now carry a debug id, which makes that easier to spot.