### PR TITLE
Apple Pay: scope domain registration state to the connected PayPal account

### DIFF
--- a/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
+++ b/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
@@ -117,10 +117,17 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
             if (!is_array($addedDomains)) {
                 $instance = AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::instance();
                 $addedDomains = $instance->listApplePayDomain(true);
-                // Never cache a failed lookup as though it were an answer.
-                if (!empty($addedDomains['status'])) {
-                    set_transient($cacheKey, $addedDomains, 24 * HOUR_IN_SECONDS);
-                }
+                // Cache the failure as well, briefly. It is not treated as an
+                // answer - the check below still throws - but without it a
+                // failing or rate-limited API is called again on every admin
+                // page render, which is what the manual process exists to
+                // avoid. A short window still lets an outage recover on its
+                // own, rather than pinning the state for a day.
+                set_transient(
+                        $cacheKey,
+                        $addedDomains,
+                        !empty($addedDomains['status']) ? 24 * HOUR_IN_SECONDS : 15 * MINUTE_IN_SECONDS
+                );
             }
         } else {
             $addedDomains = $response;

--- a/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
+++ b/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
@@ -117,22 +117,27 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
             if (!is_array($addedDomains)) {
                 $instance = AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::instance();
                 $addedDomains = $instance->listApplePayDomain(true);
-                set_transient("angelleye_apple_pay_domain_list_cache", $addedDomains, 24 * HOUR_IN_SECONDS);
+                // Never cache a failed lookup as though it were an answer.
+                if (!empty($addedDomains['status'])) {
+                    set_transient("angelleye_apple_pay_domain_list_cache", $addedDomains, 24 * HOUR_IN_SECONDS);
+                }
             }
         } else {
             $addedDomains = $response;
         }
 
-        if ($addedDomains['status'] && count($addedDomains['domains'])) {
-            $domainName = parse_url( get_site_url(), PHP_URL_HOST );
-            foreach ($addedDomains['domains'] as $addedDomain) {
-                if ($addedDomain['domain'] == $domainName) {
-                    return true;
-                }
-            }
-            return false;
+        // An account with no domains is a successful lookup reporting none;
+        // only a failed call is genuinely unknown.
+        if (empty($addedDomains['status'])) {
+            throw new Exception('Unable to retrieve apple pay domain list.');
         }
-        throw new Exception('Unable to retrieve apple pay domain list.');
+        $domainName = parse_url( get_site_url(), PHP_URL_HOST );
+        foreach ((array) ($addedDomains['domains'] ?? []) as $addedDomain) {
+            if ($addedDomain['domain'] == $domainName) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static function autoRegisterDomain($is_domain_added = false): bool

--- a/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
+++ b/ppcp-gateway/admin/class-angelleye-paypal-ppcp-apple-pay-configurations.php
@@ -100,8 +100,7 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
             $checkIsDomainAdded = self::isApplePayDomainAdded($jsonResponse);
             if ($checkIsDomainAdded) {
                 $successMessage = __('Your domain has been registered successfully, Close the popup and refresh the page to update the status.', 'paypal-for-woocommerce');
-                $applePayGateway = WC_Gateway_Apple_Pay_AngellEYE::instance();
-                $applePayGateway->update_option('apple_pay_domain_added', 'yes');
+                angelleye_ppcp_record_apple_pay_domain_added(true);
             }
         } catch (Exception $exception) {
 
@@ -113,13 +112,14 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
     public static function isApplePayDomainAdded($response = null): bool
     {
         if (empty($response)) {
-            $addedDomains = get_transient("angelleye_apple_pay_domain_list_cache");
+            $cacheKey = angelleye_ppcp_apple_pay_domain_cache_key();
+            $addedDomains = get_transient($cacheKey);
             if (!is_array($addedDomains)) {
                 $instance = AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::instance();
                 $addedDomains = $instance->listApplePayDomain(true);
                 // Never cache a failed lookup as though it were an answer.
                 if (!empty($addedDomains['status'])) {
-                    set_transient("angelleye_apple_pay_domain_list_cache", $addedDomains, 24 * HOUR_IN_SECONDS);
+                    set_transient($cacheKey, $addedDomains, 24 * HOUR_IN_SECONDS);
                 }
             }
         } else {
@@ -145,14 +145,15 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
         try {
             if (!self::isApplePayDomainAdded()) {
                 /**
-                 * Try to register the domain max 1 time, this reduces the register attempt in case add domain fails
-                 * If domain registration fails its expected user will register manually.
+                 * Try to register the domain max 1 time per connected account,
+                 * so a failure against one account does not latch registration
+                 * off for the next one.
                  */
-                $auto_register_status = get_option('ae_apple_pay_domain_reg_retries', 0);
-                if ($auto_register_status > 0) {
+                $scope = angelleye_ppcp_apple_pay_account_scope();
+                if (get_option('ae_apple_pay_domain_reg_retries', '') === $scope) {
                     return false;
                 }
-                update_option('ae_apple_pay_domain_reg_retries', 1);
+                update_option('ae_apple_pay_domain_reg_retries', $scope);
                 $instance = AngellEYE_PayPal_PPCP_Apple_Pay_Configurations::instance();
 
                 /**
@@ -216,7 +217,7 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
         $domainGetUrl = 'https://' . $this->host . '/v1/customer/wallet-domains';
         $response = $this->api_request->request($domainGetUrl, $args, 'apple_pay_domain_add');
         if (isset($response['domain'])) {
-            delete_transient('angelleye_apple_pay_domain_list_cache');
+            angelleye_ppcp_clear_apple_pay_domain_cache();
             return [
                 'status' => true,
                 'domain' => $domainNameToRegister,
@@ -257,7 +258,7 @@ class AngellEYE_PayPal_PPCP_Apple_Pay_Configurations
         $domainGetUrl = 'https://' . $this->host . '/v1/customer/unregister-wallet-domain';
         $response = $this->api_request->request($domainGetUrl, $args, 'apple_pay_domain_remove');
         if (isset($response['domain'])) {
-            delete_transient('angelleye_apple_pay_domain_list_cache');
+            angelleye_ppcp_clear_apple_pay_domain_cache();
             return [
                 'status' => true,
                 'message' => __('Domain has been removed successfully.', 'paypal-for-woocommerce')

--- a/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
+++ b/ppcp-gateway/angelleye-paypal-ppcp-common-functions.php
@@ -932,6 +932,87 @@ if (!function_exists('angelleye_ppcp_is_save_payment_method')) {
 
 }
 
+if (!function_exists('angelleye_ppcp_apple_pay_account_scope')) {
+
+    /**
+     * Identifies the connected PayPal account, so Apple Pay domain state
+     * cannot be carried over from a previously connected one.
+     *
+     * @return string
+     */
+    function angelleye_ppcp_apple_pay_account_scope() {
+        $settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
+        $is_sandbox = 'yes' === $settings->get('testmode', 'no');
+        $merchant_id = $is_sandbox
+                ? $settings->get('sandbox_merchant_id', '')
+                : $settings->get('live_merchant_id', '');
+        return substr(md5(($is_sandbox ? 'sandbox' : 'live') . '|' . $merchant_id), 0, 12);
+    }
+
+}
+
+if (!function_exists('angelleye_ppcp_apple_pay_domain_cache_key')) {
+
+    function angelleye_ppcp_apple_pay_domain_cache_key() {
+        return 'angelleye_apple_pay_domain_list_cache_' . angelleye_ppcp_apple_pay_account_scope();
+    }
+
+}
+
+if (!function_exists('angelleye_ppcp_clear_apple_pay_domain_cache')) {
+
+    function angelleye_ppcp_clear_apple_pay_domain_cache() {
+        delete_transient(angelleye_ppcp_apple_pay_domain_cache_key());
+        // Pre-scoping key, still present on existing installs.
+        delete_transient('angelleye_apple_pay_domain_list_cache');
+    }
+
+}
+
+if (!function_exists('angelleye_ppcp_is_apple_pay_domain_recorded')) {
+
+    /**
+     * Whether the domain is recorded as registered for the account connected
+     * right now. A flag left behind by a different account does not count.
+     *
+     * @return bool
+     */
+    function angelleye_ppcp_is_apple_pay_domain_recorded() {
+        $settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
+        if ('yes' !== $settings->get('apple_pay_domain_added', 'no')) {
+            return false;
+        }
+        $recorded_account = $settings->get('apple_pay_domain_added_account', '');
+        // Installs upgrading from before the flag was scoped have no account
+        // recorded against it. Honour the existing flag so a working Apple Pay
+        // is not switched off by the upgrade; the settings page stamps the
+        // connected account the next time it reconciles.
+        if ('' === $recorded_account) {
+            return true;
+        }
+        return $recorded_account === angelleye_ppcp_apple_pay_account_scope();
+    }
+
+}
+
+if (!function_exists('angelleye_ppcp_record_apple_pay_domain_added')) {
+
+    /**
+     * @param bool $is_added
+     */
+    function angelleye_ppcp_record_apple_pay_domain_added($is_added) {
+        $key = 'woocommerce_angelleye_ppcp_settings';
+        $settings = get_option($key, array());
+        if (!is_array($settings)) {
+            $settings = array();
+        }
+        $settings['apple_pay_domain_added'] = $is_added ? 'yes' : 'no';
+        $settings['apple_pay_domain_added_account'] = $is_added ? angelleye_ppcp_apple_pay_account_scope() : '';
+        update_option($key, $settings);
+    }
+
+}
+
 if (!function_exists('angelleye_ppcp_is_apple_pay_recurring_token')) {
 
     /**

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-seller-onboarding.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-seller-onboarding.php
@@ -381,7 +381,7 @@ class AngellEYE_PayPal_PPCP_Seller_Onboarding {
                 switch ($_GET['feature_activated']) {
                     case 'applepay':
                         set_transient('angelleye_ppcp_applepay_onboarding_done', 'yes', 29000);
-                        delete_transient('angelleye_apple_pay_domain_list_cache');
+                        angelleye_ppcp_clear_apple_pay_domain_cache();
                         $move_to_location = 'apple_pay_authorizations';
                         break;
                     case 'googlepay':

--- a/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
+++ b/ppcp-gateway/class-angelleye-paypal-ppcp-smart-button.php
@@ -146,7 +146,7 @@ class AngellEYE_PayPal_PPCP_Smart_Button {
         $this->advanced_card_payments_title = $this->setting_obj->get('advanced_card_payments_title', 'Credit Card');
         $this->advanced_card_payments_display_position = $this->setting_obj->get('advanced_card_payments_display_position', 'after');
         $this->enabled_pay_later_messaging = 'yes' === $this->setting_obj->get('enabled_pay_later_messaging', 'yes');
-        $is_domain_added = $this->setting_obj->get('apple_pay_domain_added', 'no') == 'yes';
+        $is_domain_added = angelleye_ppcp_is_apple_pay_domain_recorded();
         $this->enable_apple_pay = $this->enabled && $is_domain_added && 'yes' === $this->setting_obj->get('enable_apple_pay', 'no');
         $this->enable_google_pay = $this->enabled && 'yes' === $this->setting_obj->get('enable_google_pay', 'no');
         $this->pay_later_messaging_page_type = $this->setting_obj->get('pay_later_messaging_page_type', array('product', 'cart', 'payment'));

--- a/ppcp-gateway/class-wc-gateway-apple-pay-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-apple-pay-angelleye.php
@@ -75,7 +75,7 @@ class WC_Gateway_Apple_Pay_AngellEYE extends WC_Gateway_PPCP_AngellEYE {
             $this->method_title = 'PayPal Apple Pay - by Angelleye';
             $this->title = $this->setting_obj->get('apple_pay_payments_title', 'Apple Pay');
 
-            $is_domain_added = $this->setting_obj->get('apple_pay_domain_added', 'no') == 'yes';
+            $is_domain_added = angelleye_ppcp_is_apple_pay_domain_recorded();
             $this->enable_apple_pay = $is_domain_added && 'yes' === $this->setting_obj->get('enable_apple_pay', 'no');
             $this->apple_pay_payments_description = $this->setting_obj->get('apple_pay_payments_description', 'Complete your purchase by selecting your saved payment methods or using Apple Pay.');
         } catch (Exception $ex) {

--- a/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
+++ b/ppcp-gateway/class-wc-gateway-ppcp-angelleye.php
@@ -156,7 +156,7 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
         if ($gateway_being_disabled || $oldSandboxMode !== $newSandboxMode) {
             delete_option('ae_apple_pay_domain_reg_retries');
             delete_transient('ae_seller_onboarding_status');
-            delete_transient('angelleye_apple_pay_domain_list_cache');
+            angelleye_ppcp_clear_apple_pay_domain_cache();
         }
 
         if ($gateway_being_disabled) {
@@ -956,7 +956,7 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
             }
             $is_enabled = $this->get_option($key);
             $is_domain_added_new = false;
-            $is_domain_added = $this->get_option('apple_pay_domain_added', null) == 'yes';
+            $is_domain_added = angelleye_ppcp_is_apple_pay_domain_recorded();
             $is_apple_pay_approved = $data['is_apple_pay_approved'] ?? false;
             $is_apple_pay_enabled = $data['is_apple_pay_enable'] ?? false;
             $is_ppcp_connected = $data['is_ppcp_connected'] ?? false;
@@ -966,14 +966,9 @@ class WC_Gateway_PPCP_AngellEYE extends WC_Payment_Gateway {
             }
             $is_disabled = $data['disabled'] || isset($data['custom_attributes']['disabled']) || !$is_domain_added_new || !$is_apple_pay_approved;
 
-            if ($is_domain_added == null || $is_domain_added_new != $is_domain_added) {
-                if ($is_domain_added_new) {
-                    $is_domain_added = true;
-                    $this->update_option('apple_pay_domain_added', 'yes');
-                } else {
-                    $is_domain_added = false;
-                    $this->update_option('apple_pay_domain_added', 'no');
-                }
+            if ($is_domain_added_new != $is_domain_added) {
+                $is_domain_added = (bool) $is_domain_added_new;
+                angelleye_ppcp_record_apple_pay_domain_added($is_domain_added);
             }
             ob_start();
             ?>


### PR DESCRIPTION
Closes #2227

## Problem

After connecting a different PayPal account, the gateway settings page reported **"Apple Pay is connected!"** and hid the *Manage Apple Pay Domains* button, even though the domain was not registered on the newly connected account. Apple Pay then failed on the storefront at merchant validation with `ERROR_VALIDATING_MERCHANT` / `APPLE_PAY_MERCHANT_SESSION_VALIDATION_ERROR`, because PayPal had no domain registration for that merchant.

None of the stored Apple Pay domain state was tied to the account it described.

## An account with no domains was indistinguishable from a failed lookup

`isApplePayDomainAdded()` only returned a value when the domain list was non-empty:

```php
if ($addedDomains['status'] && count($addedDomains['domains'])) {
    // ...compare against site host
    return false;
}
throw new Exception('Unable to retrieve apple pay domain list.');
```

A freshly connected account reporting **zero** domains fell through to the `throw` meant for a failed API call. `autoRegisterDomain()` caught that exception and returned the previously stored flag, so:

- the settings page reported the previous account's registration for the new one, and
- automatic registration was never attempted, because the throw skipped the registration branch entirely.

Now the exception is reserved for a genuinely failed call, and an account with no domains returns `false`.

## API calls are still rate limited after a failure

The previous code cached the failure response for 24 hours, which is what stopped a failing domain API being called again on every render of the gateway settings and onboarding screens — both call `autoRegisterDomain()` during render. That protection is kept, with a shorter window: a successful lookup is cached for 24 hours, a failed one for 15 minutes.

The failure is still never mistaken for an answer — the status check throws either way — but the call is not repeated on the next page render. Worst case goes from one call per admin render to four per hour, and a transient outage recovers on its own instead of pinning the state for a day.

Automatic registration remains latched per account: `ae_apple_pay_domain_reg_retries` is written before the attempt, so a failed add is not retried automatically and the manual process stays the recovery path.

## The stored state was not scoped to an account

- `apple_pay_domain_added` was never reset when the connected account changed.
- `angelleye_apple_pay_domain_list_cache` was a single global transient (24h), cleared only on gateway disable, sandbox toggle, or an `applepay`-specific onboarding return — so a normal account connect kept the previous account's domain list.
- `ae_apple_pay_domain_reg_retries` was set to `1` after one attempt and cleared on those same two events only, latching automatic registration off for every later account.

All three are now keyed to the merchant id plus environment. Reads go through `angelleye_ppcp_is_apple_pay_domain_recorded()`, so a flag left behind by a different account does not count.

## Manual registration wrote to a store nothing read

`registerApplePayDomain()` recorded the flag against `WC_Gateway_Apple_Pay_AngellEYE` (`woocommerce_angelleye_ppcp_apple_pay_settings`), while all three read sites take it from the shared PPCP settings (`woocommerce_angelleye_ppcp_settings`). Registering by hand never updated the value anyone read. Both writes now go through one helper targeting the store that is read.

## Backward compatibility

Existing installs have no account recorded against `apple_pay_domain_added`. Both storefront read sites gate `enable_apple_pay` on that flag, so comparing against a scope that cannot match would have switched Apple Pay off for every existing merchant until an admin opened the gateway settings page.

An empty recorded account is therefore treated as belonging to the current account. Existing behaviour is preserved, and the settings page stamps the connected account the next time it reconciles, after which scope enforcement applies.

Other surfaces:

- **Transient key** — the old key is orphaned and expires within 24 hours; the first check after upgrade costs one extra API call. `angelleye_ppcp_clear_apple_pay_domain_cache()` deletes both the scoped and the pre-scoping key.
- **`ae_apple_pay_domain_reg_retries`** — changes from int `1` to a scope string; all three references are updated. The old value never matches a scope, so one automatic registration attempt is re-armed per account. Where the domain is already registered this does nothing, since `isApplePayDomainAdded()` returns `true` before the retry check.
- **`isApplePayDomainAdded()`** — signature and return type unchanged. All four callers improve; `autoUnRegisterDomain()` previously threw for an account with no domains and now correctly returns `false`.
- **Orphaned value** — `woocommerce_angelleye_ppcp_apple_pay_settings['apple_pay_domain_added']` is left behind, and was never read.

## Note on placement

The helpers live in `angelleye-paypal-ppcp-common-functions.php` rather than as statics on the admin configurations class. That class is included from `AngellEYE_PayPal_PPCP_Seller_Onboarding::__construct()` and is not guaranteed to be loaded on the front end, where two of the three read sites run.

## Not a defect, for context

PayPal will not register a domain already registered to another merchant, which is why the domain could not be added while the first account held it and could be added after connecting the second. That constraint is expected; the problem was that the plugin's stored state never caught up with which account was connected.

## Testing

`php -l` passes on every changed file and on each commit independently. No JS changed, so no asset rebuild.

Not yet exercised against a live account switch — that needs two PayPal accounts and a registered domain. The behaviour to confirm is: connect account A and register the domain, connect account B, and check that the settings page reports the domain as unregistered and offers *Manage Apple Pay Domains*, rather than claiming Apple Pay is connected.

